### PR TITLE
Fix the rasterisation bug

### DIFF
--- a/bitmap/dither_test.go
+++ b/bitmap/dither_test.go
@@ -2,9 +2,7 @@ package bitmap
 
 import (
 	"image"
-	_ "image/jpeg"
-	"image/png"
-	"os"
+	"image/color"
 	"testing"
 )
 
@@ -12,59 +10,55 @@ func resizeAndDither(img image.Image, targetWidth int, ditherFn DitherFunc) imag
 	return ditherFn(ResizeToFit(img, targetWidth), DefaultGamma)
 }
 
-func openImage(t *testing.T, filename string) image.Image {
-	t.Helper()
-	file, err := os.Open(filename)
-	if err != nil {
-		t.Fatalf("failed to open image file %s: %v", filename, err)
-	}
-	defer file.Close()
-
-	img, _, err := image.Decode(file)
-	if err != nil {
-		t.Fatalf("failed to decode image file %s: %v", filename, err)
-	}
-	return img
-}
-
-func saveImage(t *testing.T, img image.Image, filename string) {
-	t.Helper()
-	file, err := os.Create(filename)
-	if err != nil {
-		t.Fatalf("failed to create image file %s: %v", filename, err)
-	}
-	defer file.Close()
-
-	if err := png.Encode(file, img); err != nil {
-		t.Fatalf("failed to encode image to file %s: %v", filename, err)
-	}
-}
-
 func Test_resizeAndDither(t *testing.T) {
 	type args struct {
-		// img         image.Image
 		targetWidth int
 		ditherFn    DitherFunc
 	}
 	tests := []struct {
-		name   string
-		input  string
-		args   args
-		output string
+		name       string
+		input      image.Image
+		args       args
+		wantBounds image.Rectangle
 	}{
 		{
-			name:   "Resize and dither",
-			input:  "../media/harold.jpg",
-			args:   args{targetWidth: 384, ditherFn: DStucki},
-			output: "../media/harold_out.png",
+			name:       "Resize and dither",
+			input:      makeGradient(96, 24),
+			args:       args{targetWidth: 384, ditherFn: DStucki},
+			wantBounds: image.Rect(0, 0, 384, 24),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := resizeAndDither(openImage(t, tt.input), tt.args.targetWidth, tt.args.ditherFn)
-			saveImage(t, out, tt.output)
+			out := resizeAndDither(tt.input, tt.args.targetWidth, tt.args.ditherFn)
+			if got := out.Bounds(); got != tt.wantBounds {
+				t.Fatalf("resizeAndDither bounds = %v, want %v", got, tt.wantBounds)
+			}
+			assertBlackWhite(t, out)
 		})
 	}
 }
 
+func makeGradient(width, height int) image.Image {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			v := uint8(x * 255 / (width - 1))
+			img.SetGray(x, y, color.Gray{Y: v})
+		}
+	}
+	return img
+}
 
+func assertBlackWhite(t *testing.T, img image.Image) {
+	t.Helper()
+	bounds := img.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			gray := ColorToGray(img.At(x, y))
+			if gray != 0 && gray != 255 {
+				t.Fatalf("pixel at (%d,%d) = %d, want black or white", x, y, gray)
+			}
+		}
+	}
+}

--- a/bitmap/image.go
+++ b/bitmap/image.go
@@ -21,11 +21,9 @@ func PixelBit(img image.Image, x, y int, threshold uint8) bool {
 	if threshold == 0 {
 		threshold = DefaultThreshold // default threshold for dark pixels
 	}
-	if y >= img.Bounds().Dy() {
-		return false // padded line
-	}
-	if x >= img.Bounds().Dx() {
-		return false // image narrower than 384px
+	bounds := img.Bounds()
+	if !image.Pt(x, y).In(bounds) {
+		return false
 	}
 
 	c := img.At(x, y)

--- a/bitmap/image_test.go
+++ b/bitmap/image_test.go
@@ -1,0 +1,21 @@
+package bitmap
+
+import (
+	"image"
+	"testing"
+)
+
+func TestPixelBitNonZeroOriginBounds(t *testing.T) {
+	img := image.NewGray(image.Rect(10, 20, 12, 22))
+	img.Set(10, 20, image.Black)
+
+	if !PixelBit(img, 10, 20, DefaultThreshold) {
+		t.Fatal("PixelBit returned false for black pixel inside non-zero-origin bounds")
+	}
+	if PixelBit(img, 0, 0, DefaultThreshold) {
+		t.Fatal("PixelBit returned true for point outside non-zero-origin bounds")
+	}
+	if PixelBit(img, 12, 20, DefaultThreshold) {
+		t.Fatal("PixelBit returned true for point on right edge outside bounds")
+	}
+}

--- a/raster.go
+++ b/raster.go
@@ -86,10 +86,16 @@ func (r *GenericRasteriser) Serialise(img image.Image) ([][]byte, error) {
 		return nil, fmt.Errorf("image size (%d) exceeds %d pixel limit for this rasteriser", width, lineWidthPixels)
 	}
 
-	rasteriseLine := func(img image.Image, y int) []byte {
+	rasteriseLine := func(relY int) []byte {
 		lineBytes := make([]byte, lineWidthBytes)
+		if relY >= height {
+			return lineBytes
+		}
 		for x := range lineWidthPixels {
-			bit := bitmap.PixelBit(img, bounds.Min.X+x, bounds.Min.Y+y, r.Threshold)
+			if x >= width {
+				break
+			}
+			bit := bitmap.PixelBit(img, bounds.Min.X+x, bounds.Min.Y+relY, r.Threshold)
 			if bit {
 				lineBytes[x/8] |= (1 << (7 - (x % 8)))
 			}
@@ -97,31 +103,25 @@ func (r *GenericRasteriser) Serialise(img image.Image) ([][]byte, error) {
 		return lineBytes
 	}
 
-	// Pad height to even number for 2-line packets
-	if height%2 != 0 {
-		height++
+	serializedHeight := height
+	if serializedHeight%linesPerMsg != 0 {
+		serializedHeight += linesPerMsg - serializedHeight%linesPerMsg
 	} else {
-		height += 2 // ensure we have at least 2 lines for the last packet
+		serializedHeight += linesPerMsg
 	}
 
-	numPackets := height / linesPerMsg
+	numPackets := serializedHeight / linesPerMsg
 	packets := make([][]byte, 0, numPackets)
 
 	for packetIndex := range numPackets {
-		y0 := packetIndex * 2
-		y1 := y0 + 1
-
 		row := make([]byte, 0, msgPayloadSz)
 
 		row = append(row, r.PrefixFunc(packetIndex)...)
 
-		// First line (y0)
-		lineBytes := rasteriseLine(img, y0)
-		row = append(row, lineBytes...)
-
-		// Second line (y1)
-		lineBytes = rasteriseLine(img, y1)
-		row = append(row, lineBytes...)
+		for line := range linesPerMsg {
+			relY := packetIndex*linesPerMsg + line
+			row = append(row, rasteriseLine(relY)...)
+		}
 
 		row = append(row, r.Terminator) // terminating byte
 

--- a/raster_test.go
+++ b/raster_test.go
@@ -3,7 +3,7 @@ package thermoprint
 import (
 	"bytes"
 	"image"
-	"os"
+	"image/color"
 	"reflect"
 	"testing"
 
@@ -37,12 +37,12 @@ func TestRaster_Rasterise(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:   "rasterise text",
+			name:   "rasterise generated pattern",
 			fields: *LXD02Rasteriser,
 			args: args{
-				src: openImage(t, "media/rasterised.png"), // Use a sample image
+				src: makeTextLikePattern(96, 16),
 			},
-			want:    [][]byte{},
+			want:    nil,
 			wantErr: false,
 		},
 	}
@@ -54,14 +54,105 @@ func TestRaster_Rasterise(t *testing.T) {
 				t.Errorf("Raster.Rasterise() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			if tt.want == nil {
+				assertRasterPackets(t, got, r)
+				return
+			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Raster.Rasterise() = [% x], want [% x]", got, tt.want)
-				if err := os.WriteFile("test_rasterised.bin", bytes.Join(got, []byte{'\n'}), 0644); err != nil {
-					t.Fatalf("failed to write output file: %v", err)
-				}
 			}
 		})
 	}
+}
+
+func TestGenericRasteriserSerialisePadsOddHeight(t *testing.T) {
+	r := testRasteriser(8, 2)
+	img := image.NewGray(image.Rect(0, 0, 8, 1))
+	for x := range 8 {
+		img.Set(x, 0, image.Black)
+	}
+
+	got, err := r.Serialise(img)
+	if err != nil {
+		t.Fatalf("Serialise returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Serialise returned %d packets, want 1", len(got))
+	}
+	want := []byte{0x00, 0xff, 0x00, 0x00}
+	if !bytes.Equal(got[0], want) {
+		t.Fatalf("Serialise packet = [% x], want [% x]", got[0], want)
+	}
+}
+
+func TestGenericRasteriserSerialiseNonZeroOrigin(t *testing.T) {
+	r := testRasteriser(8, 2)
+	shifted := image.NewGray(image.Rect(5, 7, 13, 9))
+	zero := image.NewGray(image.Rect(0, 0, 8, 2))
+
+	for y := range 2 {
+		for x := range 8 {
+			c := color.White
+			if (x+y)%3 == 0 {
+				c = color.Black
+			}
+			shifted.Set(5+x, 7+y, c)
+			zero.Set(x, y, c)
+		}
+	}
+
+	gotShifted, err := r.Serialise(shifted)
+	if err != nil {
+		t.Fatalf("Serialise shifted image returned error: %v", err)
+	}
+	gotZero, err := r.Serialise(zero)
+	if err != nil {
+		t.Fatalf("Serialise zero-origin image returned error: %v", err)
+	}
+	if !reflect.DeepEqual(gotShifted, gotZero) {
+		t.Fatalf("Serialise shifted = [% x], want zero-origin [% x]", gotShifted, gotZero)
+	}
+}
+
+func TestGenericRasteriserSerialiseRightSidePadding(t *testing.T) {
+	r := testRasteriser(16, 2)
+	img := strictImage{Gray: image.NewGray(image.Rect(0, 0, 8, 1))}
+	for x := range 8 {
+		img.Set(x, 0, image.Black)
+	}
+
+	got, err := r.Serialise(img)
+	if err != nil {
+		t.Fatalf("Serialise returned error: %v", err)
+	}
+	want := []byte{0x00, 0xff, 0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(got[0], want) {
+		t.Fatalf("Serialise packet = [% x], want [% x]", got[0], want)
+	}
+}
+
+func testRasteriser(width, linesPerPacket int) *GenericRasteriser {
+	return &GenericRasteriser{
+		Width:          width,
+		Dpi:            203,
+		LinesPerPacket: linesPerPacket,
+		PrefixFunc: func(packetIndex int) []byte {
+			return []byte{byte(packetIndex)}
+		},
+		Terminator: 0x00,
+		Threshold:  bitmap.DefaultThreshold,
+	}
+}
+
+type strictImage struct {
+	*image.Gray
+}
+
+func (s strictImage) At(x, y int) color.Color {
+	if !image.Pt(x, y).In(s.Bounds()) {
+		panic("At called outside image bounds")
+	}
+	return s.Gray.At(x, y)
 }
 
 // makeCheckers creates a checkerboard image of the specified width and height.
@@ -80,17 +171,41 @@ func makeCheckers(t *testing.T, width, height int) image.Image {
 	return img
 }
 
-func openImage(t *testing.T, filename string) image.Image {
-	t.Helper()
-	file, err := os.Open(filename)
-	if err != nil {
-		t.Fatalf("failed to open image file %s: %v", filename, err)
-	}
-	defer file.Close()
-
-	img, _, err := image.Decode(file)
-	if err != nil {
-		t.Fatalf("failed to decode image file %s: %v", filename, err)
+func makeTextLikePattern(width, height int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			img.Set(x, y, image.White)
+			if y%6 == 1 || (x%11 < 2 && y%6 < 5) {
+				img.Set(x, y, image.Black)
+			}
+		}
 	}
 	return img
+}
+
+func assertRasterPackets(t *testing.T, got [][]byte, r *GenericRasteriser) {
+	t.Helper()
+	if len(got) == 0 {
+		t.Fatal("Serialise returned no packets")
+	}
+	packetLen := len(r.PrefixFunc(0)) + r.Width/8*r.LinesPerPacket + 1
+	nonEmpty := false
+	for i, packet := range got {
+		if len(packet) != packetLen {
+			t.Fatalf("packet %d length = %d, want %d", i, len(packet), packetLen)
+		}
+		if packet[len(packet)-1] != r.Terminator {
+			t.Fatalf("packet %d terminator = %#x, want %#x", i, packet[len(packet)-1], r.Terminator)
+		}
+		for _, b := range packet[len(r.PrefixFunc(0)) : len(packet)-1] {
+			if b != 0 {
+				nonEmpty = true
+				break
+			}
+		}
+	}
+	if !nonEmpty {
+		t.Fatal("Serialise returned only empty raster data")
+	}
 }


### PR DESCRIPTION
`GenericRasteriser.Serialise` padded odd image heights before iterating rows,
but still called `rasteriseLine` for padded rows. `bitmap.PixelBit` compared
`x` and `y` against `img.Bounds().Dx()`/`Dy()` rather than absolute
`Bounds().Max`, so padded rows or non-zero-origin images could call `img.At`
out of bounds.

Fix: make row/column bounds checks use absolute image bounds, or skip
rasterizing padded rows and emit white bytes directly.

