### PR TITLE
switch printer FSM to looplab/fsm

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,5 @@
 - [TODO] IPP protocol revisit
-- [TODO] reimplement printer FSM on looplab/fsm
+- [DONE] reimplement printer FSM on looplab/fsm
 - [DONE] requests:
 	- [DONE] 11 - get printer attributes
 	- [DONE] 2 -  print

--- a/cmd/tp/internal/golang/base/status.go
+++ b/cmd/tp/internal/golang/base/status.go
@@ -2,7 +2,7 @@ package base
 
 // StatusCode is the code returned to the OS.
 //
-//go:generate stringer -type StatusCode -linecomment
+//go:generate go tool stringer -type StatusCode -linecomment
 type StatusCode uint8
 
 // Status codes returned by the main executable.

--- a/cmd/tp/internal/golang/base/statuscode_string.go
+++ b/cmd/tp/internal/golang/base/statuscode_string.go
@@ -20,8 +20,9 @@ const _StatusCode_name = "No ErrorGeneric ErrorHelp RequestedInvalid ParametersA
 var _StatusCode_index = [...]uint8{0, 8, 21, 35, 53, 70}
 
 func (i StatusCode) String() string {
-	if i >= StatusCode(len(_StatusCode_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_StatusCode_index)-1 {
 		return "StatusCode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _StatusCode_name[_StatusCode_index[i]:_StatusCode_index[i+1]]
+	return _StatusCode_name[_StatusCode_index[idx]:_StatusCode_index[idx+1]]
 }

--- a/fsm.go
+++ b/fsm.go
@@ -42,9 +42,10 @@ const (
 var errPrintFailed = errors.New("print job failed")
 
 type fsmEvent struct {
-	kind printerEvent
-	data []byte
-	err  error
+	kind     printerEvent
+	data     []byte
+	err      error
+	streamID uint64
 }
 
 type printJob struct {
@@ -55,6 +56,7 @@ type printJob struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
 	printCancel context.CancelFunc
+	printStream uint64
 }
 
 func (p *LXD02) newPrintJob(ctx context.Context) *printJob {
@@ -146,21 +148,13 @@ func (p *LXD02) runFSM(job *printJob) {
 	}
 }
 
-func (p *LXD02) transition(evt printerEvent, data []byte) {
-	job := p.currentJob()
-	if job == nil {
-		slog.Warn("Ignoring FSM event with no active print", "event", evt)
-		if evt == eventCancel || evt == eventError {
-			p.setState(stateFailed)
-		}
-		return
-	}
-	p.dispatchJobEvent(job, fsmEvent{kind: evt, data: data})
-}
-
 func (p *LXD02) dispatchJobEvent(job *printJob, evt fsmEvent) bool {
 	if !p.isActiveJob(job) {
 		slog.Warn("Ignoring stale FSM event", "event", evt.kind)
+		return false
+	}
+	if !p.isCurrentPrintStream(job, evt) {
+		slog.Warn("Ignoring stale packet stream event", "event", evt.kind, "stream", evt.streamID)
 		return false
 	}
 
@@ -249,6 +243,9 @@ func (p *LXD02) cancelPrintBuffer(job *printJob) {
 	p.stateMu.Lock()
 	cancel := job.printCancel
 	job.printCancel = nil
+	if p.activeJob == job {
+		job.printStream++
+	}
 	p.stateMu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -267,10 +264,24 @@ func (p *LXD02) isActiveJob(job *printJob) bool {
 	return job != nil && p.activeJob == job
 }
 
-func (p *LXD02) setState(state printerState) {
+func (p *LXD02) isCurrentPrintStream(job *printJob, evt fsmEvent) bool {
+	if evt.streamID == 0 {
+		return evt.kind != eventPacketsSent
+	}
+
 	p.stateMu.Lock()
-	p.state = state
-	p.stateMu.Unlock()
+	defer p.stateMu.Unlock()
+	return p.activeJob == job && job.printStream == evt.streamID
+}
+
+func (p *LXD02) nextPrintStream(job *printJob) (uint64, bool) {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	if p.activeJob != job {
+		return 0, false
+	}
+	job.printStream++
+	return job.printStream, true
 }
 
 func (p *LXD02) setStateForJob(job *printJob, state printerState) {
@@ -312,11 +323,15 @@ func (p *LXD02) sendAndWaitForFSM(data []byte, expectPrefix []byte, timeout time
 }
 
 func (p *LXD02) startPrintBuffer(job *printJob, start int) {
-	if p.printBufferHook != nil {
-		p.printBufferHook(job, start)
+	streamID, ok := p.nextPrintStream(job)
+	if !ok {
 		return
 	}
-	p.printBuffer(job, start)
+	if p.printBufferHook != nil {
+		p.printBufferHook(job, start, streamID)
+		return
+	}
+	p.printBuffer(job, start, streamID)
 }
 
 func fsmStateToPrinterState(state string) printerState {

--- a/fsm.go
+++ b/fsm.go
@@ -49,6 +49,7 @@ type fsmEvent struct {
 
 type printJob struct {
 	fsm         *fsm.FSM
+	fsmMu       sync.Mutex
 	eventCh     chan fsmEvent
 	doneCh      chan error
 	doneOnce    sync.Once
@@ -124,7 +125,7 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 				go p.startPrintBuffer(job, packet)
 			},
 			"after_" + eventNotificationFinished.String(): func(_ context.Context, _ *fsm.Event) {
-				p.finishPrint(job)
+				go p.finishPrint(job)
 			},
 			"after_" + eventCancel.String(): func(_ context.Context, e *fsm.Event) {
 				p.failPrint(job, eventErr(e, context.Canceled))
@@ -153,6 +154,17 @@ func (p *LXD02) runFSM(job *printJob) {
 }
 
 func (p *LXD02) dispatchJobEvent(job *printJob, evt fsmEvent) bool {
+	if job == nil {
+		slog.Warn("Ignoring FSM event with no print job", "event", evt.kind)
+		return false
+	}
+
+	// Keep stream validation and transition application in one ordered section.
+	// Packet-stream goroutines dispatch directly while printer notifications are
+	// handled by runFSM, so both paths must agree on the current stream/state.
+	job.fsmMu.Lock()
+	defer job.fsmMu.Unlock()
+
 	if !p.isActiveJob(job) {
 		slog.Warn("Ignoring stale FSM event", "event", evt.kind)
 		return false

--- a/fsm.go
+++ b/fsm.go
@@ -116,8 +116,7 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 					slog.Debug("Hold signal received while waiting for printer completion")
 					return
 				}
-				slog.Warn("Hold signal received, pausing print job")
-				p.pausePrintBuffer(job)
+				slog.Warn("Hold signal received")
 			},
 			"after_" + eventNotificationRetransmit.String(): func(_ context.Context, e *fsm.Event) {
 				packet := extractRetryPacketIndex(eventData(e))
@@ -266,16 +265,6 @@ func (p *LXD02) cancelPrintBuffer(job *printJob) {
 	if p.activeJob == job {
 		job.printStream = 0
 	}
-	p.stateMu.Unlock()
-	if cancel != nil {
-		cancel()
-	}
-}
-
-func (p *LXD02) pausePrintBuffer(job *printJob) {
-	p.stateMu.Lock()
-	cancel := job.printCancel
-	job.printCancel = nil
 	p.stateMu.Unlock()
 	if cancel != nil {
 		cancel()

--- a/fsm.go
+++ b/fsm.go
@@ -89,6 +89,7 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 			{Name: eventInitComplete.String(), Src: []string{stateInitializing.String()}, Dst: statePrinting.String()},
 			{Name: eventPacketsSent.String(), Src: []string{statePrinting.String()}, Dst: stateWaitingRetry.String()},
 			{Name: eventNotificationHold.String(), Src: []string{statePrinting.String()}, Dst: statePaused.String()},
+			{Name: eventNotificationHold.String(), Src: []string{stateWaitingRetry.String()}, Dst: stateWaitingRetry.String()},
 			{Name: eventNotificationRetransmit.String(), Src: []string{statePrinting.String(), statePaused.String(), stateWaitingRetry.String()}, Dst: statePrinting.String()},
 			{Name: eventNotificationFinished.String(), Src: []string{stateWaitingRetry.String()}, Dst: stateCompleted.String()},
 			{Name: eventCancel.String(), Src: states, Dst: stateFailed.String()},
@@ -108,7 +109,11 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 			"after_" + eventPacketsSent.String(): func(_ context.Context, _ *fsm.Event) {
 				slog.Info("All packets sent, waiting for printer to complete (5a06)")
 			},
-			"after_" + eventNotificationHold.String(): func(_ context.Context, _ *fsm.Event) {
+			"after_" + eventNotificationHold.String(): func(_ context.Context, e *fsm.Event) {
+				if e.Src == stateWaitingRetry.String() {
+					slog.Debug("Hold signal received while waiting for printer completion")
+					return
+				}
 				slog.Warn("Hold signal received, pausing print job")
 				p.cancelPrintBuffer(job)
 			},

--- a/fsm.go
+++ b/fsm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/looplab/fsm"
@@ -46,7 +47,29 @@ type fsmEvent struct {
 	err  error
 }
 
-func (p *LXD02) newPrintFSM(initial printerState) *fsm.FSM {
+type printJob struct {
+	fsm         *fsm.FSM
+	eventCh     chan fsmEvent
+	doneCh      chan error
+	doneOnce    sync.Once
+	ctx         context.Context
+	cancel      context.CancelFunc
+	printCancel context.CancelFunc
+}
+
+func (p *LXD02) newPrintJob(ctx context.Context) *printJob {
+	jobCtx, cancel := context.WithCancel(ctx)
+	job := &printJob{
+		eventCh: make(chan fsmEvent, 10),
+		doneCh:  make(chan error, 1),
+		ctx:     jobCtx,
+		cancel:  cancel,
+	}
+	job.fsm = p.newPrintFSM(job, stateIdle)
+	return job
+}
+
+func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 	states := []string{
 		stateIdle.String(),
 		stateInitializing.String(),
@@ -72,80 +95,77 @@ func (p *LXD02) newPrintFSM(initial printerState) *fsm.FSM {
 		},
 		fsm.Callbacks{
 			"enter_state": func(_ context.Context, e *fsm.Event) {
-				p.setState(fsmStateToPrinterState(e.Dst))
+				p.setStateForJob(job, fsmStateToPrinterState(e.Dst))
 			},
 			"after_" + eventStart.String(): func(_ context.Context, _ *fsm.Event) {
 				slog.Info("Starting printer initialization")
-				go p.startInitSequence()
+				go p.startInitSequence(job)
 			},
 			"after_" + eventInitComplete.String(): func(_ context.Context, _ *fsm.Event) {
-				go p.beginPrint()
+				go p.beginPrint(job)
 			},
 			"after_" + eventPacketsSent.String(): func(_ context.Context, _ *fsm.Event) {
 				slog.Info("All packets sent, waiting for printer to complete (5a06)")
 			},
 			"after_" + eventNotificationHold.String(): func(_ context.Context, _ *fsm.Event) {
 				slog.Warn("Hold signal received, pausing print job")
-				p.cancelPrintBuffer()
+				p.cancelPrintBuffer(job)
 			},
 			"after_" + eventNotificationRetransmit.String(): func(_ context.Context, e *fsm.Event) {
 				packet := extractRetryPacketIndex(eventData(e))
 				slog.Warn("Retransmit request", "packet", packet)
-				p.cancelPrintBuffer()
-				go p.startPrintBuffer(packet)
+				p.cancelPrintBuffer(job)
+				go p.startPrintBuffer(job, packet)
 			},
 			"after_" + eventNotificationFinished.String(): func(_ context.Context, _ *fsm.Event) {
-				p.finishPrint()
+				p.finishPrint(job)
 			},
 			"after_" + eventCancel.String(): func(_ context.Context, e *fsm.Event) {
-				p.failPrint(eventErr(e, context.Canceled))
+				p.failPrint(job, eventErr(e, context.Canceled))
 			},
 			"after_" + eventError.String(): func(_ context.Context, e *fsm.Event) {
-				p.failPrint(eventErr(e, errPrintFailed))
+				p.failPrint(job, eventErr(e, errPrintFailed))
 			},
 		},
 	)
 }
 
-func (p *LXD02) runFSM(ctx context.Context) {
-	eventCh := p.currentEventCh()
-	if eventCh == nil {
-		slog.Warn("FSM requested without an event channel")
-		return
-	}
-
+func (p *LXD02) runFSM(job *printJob) {
 	for {
 		select {
-		case <-ctx.Done():
+		case <-job.ctx.Done():
 			slog.Debug("FSM context done, exiting")
 			return
-		case evt, ok := <-eventCh:
+		case evt, ok := <-job.eventCh:
 			if !ok {
 				slog.Debug("FSM event channel closed, exiting")
 				return
 			}
-			p.transitionEvent(evt)
+			p.dispatchJobEvent(job, evt)
 		}
 	}
 }
 
 func (p *LXD02) transition(evt printerEvent, data []byte) {
-	p.transitionEvent(fsmEvent{kind: evt, data: data})
-}
-
-func (p *LXD02) transitionEvent(evt fsmEvent) {
-	machine := p.currentFSM()
-	if machine == nil {
-		slog.Warn("Ignoring FSM event with no active print", "event", evt.kind)
-		if evt.kind == eventCancel || evt.kind == eventError {
+	job := p.currentJob()
+	if job == nil {
+		slog.Warn("Ignoring FSM event with no active print", "event", evt)
+		if evt == eventCancel || evt == eventError {
 			p.setState(stateFailed)
-			p.failPrint(eventErrFromFSMEvent(evt, errPrintFailed))
 		}
 		return
 	}
+	p.dispatchJobEvent(job, fsmEvent{kind: evt, data: data})
+}
 
-	log := slog.With("state", machine.Current(), "event", evt.kind)
-	if err := machine.Event(context.Background(), evt.kind.String(), evt.data, evt.err); err != nil {
+func (p *LXD02) dispatchJobEvent(job *printJob, evt fsmEvent) bool {
+	if !p.isActiveJob(job) {
+		slog.Warn("Ignoring stale FSM event", "event", evt.kind)
+		return false
+	}
+
+	log := slog.With("state", job.fsm.Current(), "event", evt.kind)
+	if err := job.fsm.Event(context.Background(), evt.kind.String(), evt.data, evt.err); err != nil {
 		var invalid fsm.InvalidEventError
 		var unknown fsm.UnknownEventError
 		switch {
@@ -157,14 +177,18 @@ func (p *LXD02) transitionEvent(evt fsmEvent) {
 			log.Warn("FSM event returned error", "error", err)
 		}
 	}
-	p.setState(fsmStateToPrinterState(machine.Current()))
+	p.setStateForJob(job, fsmStateToPrinterState(job.fsm.Current()))
+	return true
 }
 
-func (p *LXD02) beginPrint() {
+func (p *LXD02) beginPrint(job *printJob) {
+	if !p.isActiveJob(job) {
+		return
+	}
 	buflen := len(p.buffer)
 	if buflen == 0 {
 		slog.Error("Buffer is empty, cannot start printing")
-		p.emitEvent(fsmEvent{kind: eventError, err: errBufferEmpty})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: errBufferEmpty})
 		return
 	}
 
@@ -174,14 +198,20 @@ func (p *LXD02) beginPrint() {
 	resp, err := p.sendAndWaitForFSM(beginCmd, beginCmd[:2], 3*time.Second)
 	if err != nil {
 		slog.Error("Failed to send initial print command", "error", err)
-		p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send initial print command: %w", err)})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: fmt.Errorf("send initial print command: %w", err)})
+		return
+	}
+	if !p.isActiveJob(job) {
 		return
 	}
 	slog.Debug("Initial print command ack", "response", fmt.Sprintf("% x", resp))
-	p.startPrintBuffer(0)
+	p.startPrintBuffer(job, 0)
 }
 
-func (p *LXD02) finishPrint() {
+func (p *LXD02) finishPrint(job *printJob) {
+	if !p.isActiveJob(job) {
+		return
+	}
 	buflen := len(p.buffer)
 	m := byte((buflen >> 8) & 0xFF)
 	n := byte(buflen & 0xFF)
@@ -189,57 +219,52 @@ func (p *LXD02) finishPrint() {
 	resp, err := p.sendAndWaitForFSM(finalCmd, finalCmd[:2], 3*time.Second)
 	if err != nil {
 		slog.Error("Failed to send final end command", "error", err)
-		p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send final end command: %w", err)})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: fmt.Errorf("send final end command: %w", err)})
+		return
+	}
+	if !p.isActiveJob(job) {
 		return
 	}
 	slog.Debug("Final end-of-transmission command ack", "response", fmt.Sprintf("% x", resp))
-	p.completePrint(nil)
+	p.completePrint(job, nil)
 }
 
-func (p *LXD02) failPrint(err error) {
-	p.cancelPrintBuffer()
-	p.completePrint(err)
+func (p *LXD02) failPrint(job *printJob, err error) {
+	p.cancelPrintBuffer(job)
+	p.completePrint(job, err)
 }
 
-func (p *LXD02) completePrint(err error) {
-	p.doneOnce.Do(func() {
-		doneCh := p.currentDoneCh()
-		if doneCh == nil {
-			return
-		}
+func (p *LXD02) completePrint(job *printJob, err error) {
+	job.doneOnce.Do(func() {
+		job.cancel()
+		p.cancelPrintBuffer(job)
 		select {
-		case doneCh <- err:
+		case job.doneCh <- err:
 		default:
 		}
 	})
 }
 
-func (p *LXD02) cancelPrintBuffer() {
+func (p *LXD02) cancelPrintBuffer(job *printJob) {
 	p.stateMu.Lock()
-	cancel := p.printCancel
-	p.printCancel = nil
+	cancel := job.printCancel
+	job.printCancel = nil
 	p.stateMu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
 }
 
-func (p *LXD02) currentFSM() *fsm.FSM {
+func (p *LXD02) currentJob() *printJob {
 	p.stateMu.Lock()
 	defer p.stateMu.Unlock()
-	return p.printFSM
+	return p.activeJob
 }
 
-func (p *LXD02) currentEventCh() chan fsmEvent {
+func (p *LXD02) isActiveJob(job *printJob) bool {
 	p.stateMu.Lock()
 	defer p.stateMu.Unlock()
-	return p.eventCh
-}
-
-func (p *LXD02) currentDoneCh() chan error {
-	p.stateMu.Lock()
-	defer p.stateMu.Unlock()
-	return p.doneCh
+	return job != nil && p.activeJob == job
 }
 
 func (p *LXD02) setState(state printerState) {
@@ -248,29 +273,22 @@ func (p *LXD02) setState(state printerState) {
 	p.stateMu.Unlock()
 }
 
-func (p *LXD02) emitEvent(evt fsmEvent) bool {
-	eventCh := p.currentEventCh()
-	if eventCh == nil {
-		slog.Warn("Ignoring FSM event with no active print", "event", evt.kind)
-		return false
+func (p *LXD02) setStateForJob(job *printJob, state printerState) {
+	p.stateMu.Lock()
+	if p.activeJob == job {
+		p.state = state
 	}
-	select {
-	case eventCh <- evt:
-		return true
-	default:
-		slog.Warn("Dropping FSM event because event channel is full", "event", evt.kind)
-		return false
-	}
+	p.stateMu.Unlock()
 }
 
 func (p *LXD02) routeNotificationEvent(evt fsmEvent) bool {
-	eventCh := p.currentEventCh()
-	if eventCh == nil {
+	job := p.currentJob()
+	if job == nil {
 		slog.Warn("Ignoring printer notification with no active print", "event", evt.kind)
 		return false
 	}
 	select {
-	case eventCh <- evt:
+	case job.eventCh <- evt:
 		return true
 	default:
 		slog.Warn("Dropping printer notification because event channel is not ready", "event", evt.kind)
@@ -278,12 +296,12 @@ func (p *LXD02) routeNotificationEvent(evt fsmEvent) bool {
 	}
 }
 
-func (p *LXD02) startInitSequence() {
+func (p *LXD02) startInitSequence(job *printJob) {
 	if p.initSequenceHook != nil {
-		p.initSequenceHook()
+		p.initSequenceHook(job)
 		return
 	}
-	p.sendInitSequence()
+	p.sendInitSequence(job)
 }
 
 func (p *LXD02) sendAndWaitForFSM(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
@@ -293,12 +311,12 @@ func (p *LXD02) sendAndWaitForFSM(data []byte, expectPrefix []byte, timeout time
 	return p.sendAndWait(data, expectPrefix, timeout)
 }
 
-func (p *LXD02) startPrintBuffer(start int) {
+func (p *LXD02) startPrintBuffer(job *printJob, start int) {
 	if p.printBufferHook != nil {
-		p.printBufferHook(start)
+		p.printBufferHook(job, start)
 		return
 	}
-	p.printBuffer(start)
+	p.printBuffer(job, start)
 }
 
 func fsmStateToPrinterState(state string) printerState {
@@ -337,13 +355,6 @@ func eventErr(e *fsm.Event, fallback error) error {
 		if err, ok := e.Args[1].(error); ok && err != nil {
 			return err
 		}
-	}
-	return fallback
-}
-
-func eventErrFromFSMEvent(evt fsmEvent, fallback error) error {
-	if evt.err != nil {
-		return evt.err
 	}
 	return fallback
 }

--- a/fsm.go
+++ b/fsm.go
@@ -57,6 +57,7 @@ type printJob struct {
 	cancel      context.CancelFunc
 	printCancel context.CancelFunc
 	printStream uint64
+	printSeq    uint64
 }
 
 func (p *LXD02) newPrintJob(ctx context.Context) *printJob {
@@ -244,7 +245,7 @@ func (p *LXD02) cancelPrintBuffer(job *printJob) {
 	cancel := job.printCancel
 	job.printCancel = nil
 	if p.activeJob == job {
-		job.printStream++
+		job.printStream = 0
 	}
 	p.stateMu.Unlock()
 	if cancel != nil {
@@ -280,7 +281,8 @@ func (p *LXD02) nextPrintStream(job *printJob) (uint64, bool) {
 	if p.activeJob != job {
 		return 0, false
 	}
-	job.printStream++
+	job.printSeq++
+	job.printStream = job.printSeq
 	return job.printStream, true
 }
 

--- a/fsm.go
+++ b/fsm.go
@@ -166,11 +166,14 @@ func (p *LXD02) dispatchJobEvent(job *printJob, evt fsmEvent) bool {
 	if err := job.fsm.Event(context.Background(), evt.kind.String(), evt.data, evt.err); err != nil {
 		var invalid fsm.InvalidEventError
 		var unknown fsm.UnknownEventError
+		var noTransition fsm.NoTransitionError
 		switch {
 		case errors.As(err, &invalid):
 			log.Warn("Ignoring inappropriate FSM event", "error", err)
 		case errors.As(err, &unknown):
 			log.Warn("Ignoring unknown FSM event", "error", err)
+		case errors.As(err, &noTransition) && noTransition.Err == nil:
+			log.Debug("Ignoring no-op FSM event")
 		default:
 			log.Warn("FSM event returned error", "error", err)
 		}

--- a/fsm.go
+++ b/fsm.go
@@ -17,7 +17,6 @@ type printerState int
 const (
 	stateIdle printerState = iota
 	stateInitializing
-	stateReady
 	statePrinting
 	statePaused
 	stateWaitingRetry
@@ -76,7 +75,6 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 	states := []string{
 		stateIdle.String(),
 		stateInitializing.String(),
-		stateReady.String(),
 		statePrinting.String(),
 		statePaused.String(),
 		stateWaitingRetry.String(),
@@ -342,8 +340,6 @@ func fsmStateToPrinterState(state string) printerState {
 		return stateIdle
 	case stateInitializing.String():
 		return stateInitializing
-	case stateReady.String():
-		return stateReady
 	case statePrinting.String():
 		return statePrinting
 	case statePaused.String():

--- a/fsm.go
+++ b/fsm.go
@@ -89,6 +89,7 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 			{Name: eventStart.String(), Src: []string{stateIdle.String(), stateCompleted.String(), stateFailed.String()}, Dst: stateInitializing.String()},
 			{Name: eventInitComplete.String(), Src: []string{stateInitializing.String()}, Dst: statePrinting.String()},
 			{Name: eventPacketsSent.String(), Src: []string{statePrinting.String()}, Dst: stateWaitingRetry.String()},
+			{Name: eventPacketsSent.String(), Src: []string{statePaused.String()}, Dst: stateWaitingRetry.String()},
 			{Name: eventNotificationHold.String(), Src: []string{statePrinting.String()}, Dst: statePaused.String()},
 			{Name: eventNotificationHold.String(), Src: []string{stateWaitingRetry.String()}, Dst: stateWaitingRetry.String()},
 			{Name: eventNotificationRetransmit.String(), Src: []string{statePrinting.String(), statePaused.String(), stateWaitingRetry.String()}, Dst: statePrinting.String()},
@@ -116,7 +117,7 @@ func (p *LXD02) newPrintFSM(job *printJob, initial printerState) *fsm.FSM {
 					return
 				}
 				slog.Warn("Hold signal received, pausing print job")
-				p.cancelPrintBuffer(job)
+				p.pausePrintBuffer(job)
 			},
 			"after_" + eventNotificationRetransmit.String(): func(_ context.Context, e *fsm.Event) {
 				packet := extractRetryPacketIndex(eventData(e))
@@ -265,6 +266,16 @@ func (p *LXD02) cancelPrintBuffer(job *printJob) {
 	if p.activeJob == job {
 		job.printStream = 0
 	}
+	p.stateMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (p *LXD02) pausePrintBuffer(job *printJob) {
+	p.stateMu.Lock()
+	cancel := job.printCancel
+	job.printCancel = nil
 	p.stateMu.Unlock()
 	if cancel != nil {
 		cancel()

--- a/fsm.go
+++ b/fsm.go
@@ -2,14 +2,17 @@ package thermoprint
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/looplab/fsm"
 )
 
 type printerState int
 
-//go:generate stringer -type=printerState -trimprefix=state
+//go:generate go tool stringer -type=printerState -trimprefix=state
 const (
 	stateIdle printerState = iota
 	stateInitializing
@@ -23,164 +26,255 @@ const (
 
 type printerEvent int
 
-//go:generate stringer -type=printerEvent -trimprefix=event
+//go:generate go tool stringer -type=printerEvent -trimprefix=event
 const (
 	eventStart printerEvent = iota
 	eventNotificationHold
 	eventNotificationRetransmit
 	eventNotificationFinished
 	eventInitComplete
+	eventPacketsSent
 	eventCancel
 	eventError
 )
 
+var errPrintFailed = errors.New("print job failed")
+
 type fsmEvent struct {
 	kind printerEvent
 	data []byte
+	err  error
+}
+
+func (p *LXD02) newPrintFSM(initial printerState) *fsm.FSM {
+	states := []string{
+		stateIdle.String(),
+		stateInitializing.String(),
+		stateReady.String(),
+		statePrinting.String(),
+		statePaused.String(),
+		stateWaitingRetry.String(),
+		stateCompleted.String(),
+		stateFailed.String(),
+	}
+
+	return fsm.NewFSM(
+		initial.String(),
+		fsm.Events{
+			{Name: eventStart.String(), Src: []string{stateIdle.String(), stateCompleted.String(), stateFailed.String()}, Dst: stateInitializing.String()},
+			{Name: eventInitComplete.String(), Src: []string{stateInitializing.String()}, Dst: statePrinting.String()},
+			{Name: eventPacketsSent.String(), Src: []string{statePrinting.String()}, Dst: stateWaitingRetry.String()},
+			{Name: eventNotificationHold.String(), Src: []string{statePrinting.String()}, Dst: statePaused.String()},
+			{Name: eventNotificationRetransmit.String(), Src: []string{statePrinting.String(), statePaused.String(), stateWaitingRetry.String()}, Dst: statePrinting.String()},
+			{Name: eventNotificationFinished.String(), Src: []string{stateWaitingRetry.String()}, Dst: stateCompleted.String()},
+			{Name: eventCancel.String(), Src: states, Dst: stateFailed.String()},
+			{Name: eventError.String(), Src: states, Dst: stateFailed.String()},
+		},
+		fsm.Callbacks{
+			"enter_state": func(_ context.Context, e *fsm.Event) {
+				p.setState(fsmStateToPrinterState(e.Dst))
+			},
+			"after_" + eventStart.String(): func(_ context.Context, _ *fsm.Event) {
+				slog.Info("Starting printer initialization")
+				go p.startInitSequence()
+			},
+			"after_" + eventInitComplete.String(): func(_ context.Context, _ *fsm.Event) {
+				go p.beginPrint()
+			},
+			"after_" + eventPacketsSent.String(): func(_ context.Context, _ *fsm.Event) {
+				slog.Info("All packets sent, waiting for printer to complete (5a06)")
+			},
+			"after_" + eventNotificationHold.String(): func(_ context.Context, _ *fsm.Event) {
+				slog.Warn("Hold signal received, pausing print job")
+				p.cancelPrintBuffer()
+			},
+			"after_" + eventNotificationRetransmit.String(): func(_ context.Context, e *fsm.Event) {
+				packet := extractRetryPacketIndex(eventData(e))
+				slog.Warn("Retransmit request", "packet", packet)
+				p.cancelPrintBuffer()
+				go p.startPrintBuffer(packet)
+			},
+			"after_" + eventNotificationFinished.String(): func(_ context.Context, _ *fsm.Event) {
+				p.finishPrint()
+			},
+			"after_" + eventCancel.String(): func(_ context.Context, e *fsm.Event) {
+				p.failPrint(eventErr(e, context.Canceled))
+			},
+			"after_" + eventError.String(): func(_ context.Context, e *fsm.Event) {
+				p.failPrint(eventErr(e, errPrintFailed))
+			},
+		},
+	)
 }
 
 func (p *LXD02) runFSM(ctx context.Context) {
+	eventCh := p.currentEventCh()
+	if eventCh == nil {
+		slog.Warn("FSM requested without an event channel")
+		return
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
-			p.transition(eventCancel, nil)
+			slog.Debug("FSM context done, exiting")
 			return
-		case evt := <-p.eventCh:
-			p.transition(evt.kind, evt.data)
+		case evt, ok := <-eventCh:
+			if !ok {
+				slog.Debug("FSM event channel closed, exiting")
+				return
+			}
+			p.transitionEvent(evt)
 		}
 	}
 }
 
 func (p *LXD02) transition(evt printerEvent, data []byte) {
-	p.stateMu.Lock()
-	defer p.stateMu.Unlock()
+	p.transitionEvent(fsmEvent{kind: evt, data: data})
+}
 
-	log := slog.With("state", p.state, "event", evt)
-
-	switch p.state {
-
-	case stateIdle, stateCompleted:
-		if evt == eventStart {
-			log.Info("Starting printer initialization")
-			p.state = stateInitializing
-			go p.startInitSequence()
+func (p *LXD02) transitionEvent(evt fsmEvent) {
+	machine := p.currentFSM()
+	if machine == nil {
+		slog.Warn("Ignoring FSM event with no active print", "event", evt.kind)
+		if evt.kind == eventCancel || evt.kind == eventError {
+			p.setState(stateFailed)
+			p.failPrint(eventErrFromFSMEvent(evt, errPrintFailed))
 		}
-
-	case stateInitializing:
-		if evt == eventInitComplete {
-			log.Info("Printer ready after status")
-			p.state = stateReady
-			go func() {
-				slog.Debug("switching to printing state")
-				p.stateMu.Lock()
-				p.state = statePrinting
-				p.stateMu.Unlock()
-				buflen := len(p.buffer)
-				if buflen == 0 {
-					slog.Error("Buffer is empty, cannot start printing")
-					p.eventCh <- fsmEvent{kind: eventError}
-					return
-				}
-				m := byte((buflen >> 8) & 0xFF)
-				n := byte(buflen & 0xFF)
-
-				slog.Debug("Sending initial print command")
-				beginCmd := []byte{0x5a, 0x04, m, n, 0x00, 0x00}
-				resp, err := p.sendAndWaitForFSM(beginCmd, beginCmd[:2], 3*time.Second)
-				if err != nil {
-					slog.Error("Failed to send initial print command", "error", err)
-					p.eventCh <- fsmEvent{kind: eventError}
-					return
-				}
-				slog.Debug("Initial print command ack", "response", fmt.Sprintf("% x", resp))
-				p.startPrintBuffer(0)
-			}()
-		}
-
-	case statePrinting:
-		switch evt {
-
-		case eventNotificationHold:
-			log.Warn("Hold signal received, pausing print job")
-			if p.printCancel != nil {
-				p.printCancel()
-			}
-			p.state = statePaused
-
-		case eventNotificationRetransmit:
-			packet := extractRetryPacketIndex(data)
-			log.Warn("Retransmit request", "packet", packet)
-			if p.printCancel != nil {
-				p.printCancel()
-			}
-			p.state = statePrinting
-			go p.startPrintBuffer(packet)
-		case eventError:
-			log.Error("Error occurred during print")
-			if p.printCancel != nil {
-				p.printCancel()
-			}
-			p.state = stateFailed
-			p.doneCh <- struct{}{}
-		case eventNotificationFinished:
-			log.Info("data sent, waiting for printer to complete")
-			p.state = stateWaitingRetry
-		default:
-			log.Warn("Unexpected event during printing", "event", evt)
-		}
-
-	case stateWaitingRetry:
-		switch evt {
-		case eventNotificationFinished:
-			log.Info("Printer reports print complete, sending finalization")
-			p.state = stateCompleted
-
-			buflen := len(p.buffer)
-			m := byte((buflen >> 8) & 0xFF)
-			n := byte(buflen & 0xFF)
-			finalCmd := []byte{0x5a, 0x04, m, n, 0x01, 0x00}
-			resp, err := p.sendAndWaitForFSM(finalCmd, finalCmd[:2], 3*time.Second)
-			if err != nil {
-				slog.Error("Failed to send final end command", "error", err)
-				p.eventCh <- fsmEvent{kind: eventError}
-				return
-			}
-			slog.Debug("Final end-of-transmission command ack", "response", fmt.Sprintf("% x", resp))
-			p.doneCh <- struct{}{}
-		case eventNotificationHold:
-			// holding
-		case eventNotificationRetransmit:
-			packet := extractRetryPacketIndex(data)
-			log.Warn("Retransmit request in waiting retry state", "packet", packet)
-			p.state = statePrinting
-			go p.startPrintBuffer(packet)
-		default:
-			log.Warn("Unexpected event in waiting retry state", "event", evt)
-		}
-
-	case statePaused:
-		if evt == eventNotificationRetransmit {
-			packet := extractRetryPacketIndex(data)
-			log.Info("Resuming print after hold", "packet", packet)
-			p.state = statePrinting
-			go p.startPrintBuffer(packet)
-		}
-
-	case stateFailed:
-		log.Warn("Already in failed state, ignoring event")
-
-	default:
-		log.Warn("Unhandled state", "state", p.state, "event", evt)
+		return
 	}
 
-	// Global cancellation or error
-	if p.state != stateCompleted && (evt == eventCancel || evt == eventError) {
-		if p.printCancel != nil {
-			p.printCancel()
+	log := slog.With("state", machine.Current(), "event", evt.kind)
+	if err := machine.Event(context.Background(), evt.kind.String(), evt.data, evt.err); err != nil {
+		var invalid fsm.InvalidEventError
+		var unknown fsm.UnknownEventError
+		switch {
+		case errors.As(err, &invalid):
+			log.Warn("Ignoring inappropriate FSM event", "error", err)
+		case errors.As(err, &unknown):
+			log.Warn("Ignoring unknown FSM event", "error", err)
+		default:
+			log.Warn("FSM event returned error", "error", err)
 		}
-		log.Error("Job canceled or failed")
-		p.state = stateFailed
-		p.doneCh <- struct{}{}
+	}
+	p.setState(fsmStateToPrinterState(machine.Current()))
+}
+
+func (p *LXD02) beginPrint() {
+	buflen := len(p.buffer)
+	if buflen == 0 {
+		slog.Error("Buffer is empty, cannot start printing")
+		p.emitEvent(fsmEvent{kind: eventError, err: errBufferEmpty})
+		return
+	}
+
+	m := byte((buflen >> 8) & 0xFF)
+	n := byte(buflen & 0xFF)
+	beginCmd := []byte{0x5a, 0x04, m, n, 0x00, 0x00}
+	resp, err := p.sendAndWaitForFSM(beginCmd, beginCmd[:2], 3*time.Second)
+	if err != nil {
+		slog.Error("Failed to send initial print command", "error", err)
+		p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send initial print command: %w", err)})
+		return
+	}
+	slog.Debug("Initial print command ack", "response", fmt.Sprintf("% x", resp))
+	p.startPrintBuffer(0)
+}
+
+func (p *LXD02) finishPrint() {
+	buflen := len(p.buffer)
+	m := byte((buflen >> 8) & 0xFF)
+	n := byte(buflen & 0xFF)
+	finalCmd := []byte{0x5a, 0x04, m, n, 0x01, 0x00}
+	resp, err := p.sendAndWaitForFSM(finalCmd, finalCmd[:2], 3*time.Second)
+	if err != nil {
+		slog.Error("Failed to send final end command", "error", err)
+		p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send final end command: %w", err)})
+		return
+	}
+	slog.Debug("Final end-of-transmission command ack", "response", fmt.Sprintf("% x", resp))
+	p.completePrint(nil)
+}
+
+func (p *LXD02) failPrint(err error) {
+	p.cancelPrintBuffer()
+	p.completePrint(err)
+}
+
+func (p *LXD02) completePrint(err error) {
+	p.doneOnce.Do(func() {
+		doneCh := p.currentDoneCh()
+		if doneCh == nil {
+			return
+		}
+		select {
+		case doneCh <- err:
+		default:
+		}
+	})
+}
+
+func (p *LXD02) cancelPrintBuffer() {
+	p.stateMu.Lock()
+	cancel := p.printCancel
+	p.printCancel = nil
+	p.stateMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (p *LXD02) currentFSM() *fsm.FSM {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	return p.printFSM
+}
+
+func (p *LXD02) currentEventCh() chan fsmEvent {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	return p.eventCh
+}
+
+func (p *LXD02) currentDoneCh() chan error {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	return p.doneCh
+}
+
+func (p *LXD02) setState(state printerState) {
+	p.stateMu.Lock()
+	p.state = state
+	p.stateMu.Unlock()
+}
+
+func (p *LXD02) emitEvent(evt fsmEvent) bool {
+	eventCh := p.currentEventCh()
+	if eventCh == nil {
+		slog.Warn("Ignoring FSM event with no active print", "event", evt.kind)
+		return false
+	}
+	select {
+	case eventCh <- evt:
+		return true
+	default:
+		slog.Warn("Dropping FSM event because event channel is full", "event", evt.kind)
+		return false
+	}
+}
+
+func (p *LXD02) routeNotificationEvent(evt fsmEvent) bool {
+	eventCh := p.currentEventCh()
+	if eventCh == nil {
+		slog.Warn("Ignoring printer notification with no active print", "event", evt.kind)
+		return false
+	}
+	select {
+	case eventCh <- evt:
+		return true
+	default:
+		slog.Warn("Dropping printer notification because event channel is not ready", "event", evt.kind)
+		return false
 	}
 }
 
@@ -205,4 +299,51 @@ func (p *LXD02) startPrintBuffer(start int) {
 		return
 	}
 	p.printBuffer(start)
+}
+
+func fsmStateToPrinterState(state string) printerState {
+	switch state {
+	case stateIdle.String():
+		return stateIdle
+	case stateInitializing.String():
+		return stateInitializing
+	case stateReady.String():
+		return stateReady
+	case statePrinting.String():
+		return statePrinting
+	case statePaused.String():
+		return statePaused
+	case stateWaitingRetry.String():
+		return stateWaitingRetry
+	case stateCompleted.String():
+		return stateCompleted
+	case stateFailed.String():
+		return stateFailed
+	default:
+		return stateFailed
+	}
+}
+
+func eventData(e *fsm.Event) []byte {
+	if len(e.Args) == 0 {
+		return nil
+	}
+	data, _ := e.Args[0].([]byte)
+	return data
+}
+
+func eventErr(e *fsm.Event, fallback error) error {
+	if len(e.Args) > 1 {
+		if err, ok := e.Args[1].(error); ok && err != nil {
+			return err
+		}
+	}
+	return fallback
+}
+
+func eventErrFromFSMEvent(evt fsmEvent, fallback error) error {
+	if evt.err != nil {
+		return evt.err
+	}
+	return fallback
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -425,6 +425,9 @@ func TestFSM(t *testing.T) {
 		if second.streamID == first.streamID {
 			t.Fatal("retransmit did not create a new stream ID")
 		}
+		if second.streamID != first.streamID+1 {
+			t.Fatalf("second stream ID = %d, want %d", second.streamID, first.streamID+1)
+		}
 
 		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: first.streamID}); ok {
 			t.Fatal("stale packet completion was accepted")

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -351,6 +351,23 @@ func TestFSM(t *testing.T) {
 		waitForState(t, p, statePaused)
 	})
 
+	t.Run("hold while waiting for completion stays waiting", func(t *testing.T) {
+		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
+		setFSMState(p, stateWaitingRetry)
+		cancelled := make(chan struct{})
+		job.printCancel = func() {
+			close(cancelled)
+		}
+
+		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold}); !ok {
+			t.Fatal("hold in waiting retry was ignored")
+		}
+
+		waitForState(t, p, stateWaitingRetry)
+		requireNoFinish(t, cancelled)
+	})
+
 	for _, tc := range []struct {
 		name  string
 		state printerState

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -26,26 +26,32 @@ func newFSMTestPrinter(packetCount int) *LXD02 {
 		buffer[i] = []byte{byte(i)}
 	}
 	p := &LXD02{
-		buffer:  buffer,
-		state:   stateIdle,
-		eventCh: make(chan fsmEvent, 20),
-		doneCh:  make(chan error, 2),
+		buffer: buffer,
+		state:  stateIdle,
 		options: printOptions{
 			printInterval: time.Millisecond,
 		},
 	}
-	p.printFSM = p.newPrintFSM(stateIdle)
+	job := p.newPrintJob(context.Background())
+	p.activeJob = job
 	return p
+}
+
+func activeTestJob(t *testing.T, p *LXD02) *printJob {
+	t.Helper()
+
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	if p.activeJob == nil {
+		t.Fatal("active job is nil")
+	}
+	return p.activeJob
 }
 
 func setFSMState(p *LXD02, state printerState) {
 	p.stateMu.Lock()
 	p.state = state
-	if p.printFSM == nil {
-		p.printFSM = p.newPrintFSM(state)
-	} else {
-		p.printFSM.SetState(state.String())
-	}
+	p.activeJob.fsm.SetState(state.String())
 	p.stateMu.Unlock()
 }
 
@@ -122,20 +128,20 @@ func requireNoFinish(t *testing.T, finished <-chan struct{}) {
 func TestFSM(t *testing.T) {
 	t.Run("successful flow", func(t *testing.T) {
 		p := newFSMTestPrinter(3)
-		p.doneCh = make(chan error, 1)
+		job := activeTestJob(t, p)
 
 		initCalled := make(chan struct{})
 		releaseInit := make(chan struct{})
-		p.initSequenceHook = func() {
+		p.initSequenceHook = func(job *printJob) {
 			close(initCalled)
 			<-releaseInit
-			p.emitEvent(fsmEvent{kind: eventInitComplete})
+			p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
 		}
 
 		streamStarts := make(chan int, 1)
-		p.printBufferHook = func(start int) {
+		p.printBufferHook = func(job *printJob, start int) {
 			streamStarts <- start
-			p.emitEvent(fsmEvent{kind: eventPacketsSent})
+			p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent})
 		}
 
 		var (
@@ -153,11 +159,9 @@ func TestFSM(t *testing.T) {
 			return append([]byte(nil), expectPrefix...), nil
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go p.runFSM(ctx)
+		go p.runFSM(job)
 
-		p.emitEvent(fsmEvent{kind: eventStart})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventStart})
 
 		select {
 		case <-initCalled:
@@ -186,8 +190,8 @@ func TestFSM(t *testing.T) {
 		}
 		callsMu.Unlock()
 
-		p.emitEvent(fsmEvent{kind: eventNotificationFinished})
-		if err := requireDone(t, p.doneCh); err != nil {
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationFinished})
+		if err := requireDone(t, job.doneCh); err != nil {
 			t.Fatalf("done error = %v, want nil", err)
 		}
 		waitForState(t, p, stateCompleted)
@@ -205,16 +209,15 @@ func TestFSM(t *testing.T) {
 	t.Run("init failure transitions and returns error", func(t *testing.T) {
 		wantErr := errors.New("init failed")
 		p := newFSMTestPrinter(1)
-		p.initSequenceHook = func() {
-			p.emitEvent(fsmEvent{kind: eventError, err: wantErr})
+		job := activeTestJob(t, p)
+		p.initSequenceHook = func(job *printJob) {
+			p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: wantErr})
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go p.runFSM(ctx)
+		go p.runFSM(job)
 
-		p.emitEvent(fsmEvent{kind: eventStart})
-		if err := requireDone(t, p.doneCh); !errors.Is(err, wantErr) {
+		p.dispatchJobEvent(job, fsmEvent{kind: eventStart})
+		if err := requireDone(t, job.doneCh); !errors.Is(err, wantErr) {
 			t.Fatalf("done error = %v, want %v", err, wantErr)
 		}
 		waitForState(t, p, stateFailed)
@@ -223,19 +226,18 @@ func TestFSM(t *testing.T) {
 	t.Run("begin command failure transitions and returns error", func(t *testing.T) {
 		wantErr := errors.New("begin failed")
 		p := newFSMTestPrinter(1)
-		p.initSequenceHook = func() {
-			p.emitEvent(fsmEvent{kind: eventInitComplete})
+		job := activeTestJob(t, p)
+		p.initSequenceHook = func(job *printJob) {
+			p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
 		}
 		p.sendAndWaitHook = func([]byte, []byte, time.Duration) ([]byte, error) {
 			return nil, wantErr
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go p.runFSM(ctx)
+		go p.runFSM(job)
 
-		p.emitEvent(fsmEvent{kind: eventStart})
-		err := requireDone(t, p.doneCh)
+		p.dispatchJobEvent(job, fsmEvent{kind: eventStart})
+		err := requireDone(t, job.doneCh)
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("done error = %v, want %v", err, wantErr)
 		}
@@ -245,17 +247,16 @@ func TestFSM(t *testing.T) {
 	t.Run("final command failure transitions and returns error", func(t *testing.T) {
 		wantErr := errors.New("final failed")
 		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
 		setFSMState(p, stateWaitingRetry)
 		p.sendAndWaitHook = func([]byte, []byte, time.Duration) ([]byte, error) {
 			return nil, wantErr
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go p.runFSM(ctx)
+		go p.runFSM(job)
 
-		p.emitEvent(fsmEvent{kind: eventNotificationFinished})
-		err := requireDone(t, p.doneCh)
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationFinished})
+		err := requireDone(t, job.doneCh)
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("done error = %v, want %v", err, wantErr)
 		}
@@ -264,28 +265,29 @@ func TestFSM(t *testing.T) {
 
 	t.Run("packet send failure emits error", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
 		wantErr := errors.New("packet failed")
 		p.sendPacketHook = func([]byte) error {
 			return wantErr
 		}
 
-		p.printBuffer(0)
-		got := requireEvent(t, p.eventCh, eventError)
-		if !errors.Is(got.err, wantErr) {
-			t.Fatalf("event error = %v, want %v", got.err, wantErr)
+		p.printBuffer(job, 0)
+		err := requireDone(t, job.doneCh)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("done error = %v, want %v", err, wantErr)
 		}
 	})
 
 	t.Run("context cancellation returns cancellation error", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
-		p.initSequenceHook = func() {
-			p.emitEvent(fsmEvent{kind: eventInitComplete})
+		p.initSequenceHook = func(job *printJob) {
+			p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
 		}
 		p.sendAndWaitHook = func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
 			return append([]byte(nil), expectPrefix...), nil
 		}
 		streamStarted := make(chan struct{})
-		p.printBufferHook = func(int) {
+		p.printBufferHook = func(*printJob, int) {
 			close(streamStarted)
 		}
 
@@ -314,10 +316,11 @@ func TestFSM(t *testing.T) {
 
 	t.Run("hold during printing cancels stream and pauses", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
 		setFSMState(p, statePrinting)
 		cancelled := make(chan struct{})
 		var once sync.Once
-		p.printCancel = func() {
+		job.printCancel = func() {
 			once.Do(func() { close(cancelled) })
 		}
 
@@ -358,9 +361,10 @@ func TestFSM(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := newFSMTestPrinter(10)
+			job := activeTestJob(t, p)
 			setFSMState(p, tc.state)
 			starts := make(chan int, 1)
-			p.printBufferHook = func(start int) {
+			p.printBufferHook = func(_ *printJob, start int) {
 				starts <- start
 			}
 
@@ -375,28 +379,29 @@ func TestFSM(t *testing.T) {
 			case <-time.After(fsmWaitTimeout):
 				t.Fatal("print stream was not restarted")
 			}
+
+			job.cancel()
 		})
 	}
 
 	t.Run("duplicate error and cancel complete once without blocking", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
 		setFSMState(p, statePrinting)
-		p.doneCh = make(chan error, 2)
 
 		p.transition(eventError, nil)
 		p.transition(eventCancel, nil)
 
-		if err := requireDone(t, p.doneCh); !errors.Is(err, errPrintFailed) {
+		if err := requireDone(t, job.doneCh); !errors.Is(err, errPrintFailed) {
 			t.Fatalf("done error = %v, want %v", err, errPrintFailed)
 		}
-		requireNoDone(t, p.doneCh)
+		requireNoDone(t, job.doneCh)
 		waitForState(t, p, stateFailed)
 	})
 
 	t.Run("cancel after failed does not block without a done receiver", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
 		setFSMState(p, stateFailed)
-		p.doneCh = make(chan error)
 		finished := make(chan struct{})
 
 		go func() {
@@ -408,6 +413,199 @@ func TestFSM(t *testing.T) {
 		case <-finished:
 		case <-time.After(fsmWaitTimeout):
 			t.Fatal("transition blocked without a done receiver")
+		}
+	})
+
+	t.Run("internal event is delivered when notification queue is full", func(t *testing.T) {
+		wantErr := errors.New("final failed")
+		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
+		setFSMState(p, stateWaitingRetry)
+		p.sendAndWaitHook = func([]byte, []byte, time.Duration) ([]byte, error) {
+			return nil, wantErr
+		}
+		for i := 0; i < cap(job.eventCh); i++ {
+			job.eventCh <- fsmEvent{kind: eventNotificationHold}
+		}
+
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationFinished})
+
+		err := requireDone(t, job.doneCh)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("done error = %v, want %v", err, wantErr)
+		}
+		waitForState(t, p, stateFailed)
+	})
+
+	t.Run("stale init completion does not affect next print", func(t *testing.T) {
+		p := newFSMTestPrinter(1)
+		var (
+			mu         sync.Mutex
+			firstJob   *printJob
+			secondJob  *printJob
+			initCalls  int
+			streamJobs []*printJob
+		)
+		firstInitStarted := make(chan struct{})
+		releaseFirstInit := make(chan struct{})
+		secondStreamStarted := make(chan struct{})
+		p.initSequenceHook = func(job *printJob) {
+			mu.Lock()
+			initCalls++
+			call := initCalls
+			if call == 1 {
+				firstJob = job
+			} else if call == 2 {
+				secondJob = job
+			}
+			mu.Unlock()
+
+			if call == 1 {
+				close(firstInitStarted)
+				<-releaseFirstInit
+				p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
+				return
+			}
+			p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
+		}
+		p.sendAndWaitHook = func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
+			return append([]byte(nil), expectPrefix...), nil
+		}
+		p.printBufferHook = func(job *printJob, start int) {
+			mu.Lock()
+			streamJobs = append(streamJobs, job)
+			mu.Unlock()
+			if start != 0 {
+				t.Errorf("stream start = %d, want 0", start)
+			}
+			close(secondStreamStarted)
+		}
+
+		ctxA, cancelA := context.WithCancel(context.Background())
+		errA := make(chan error, 1)
+		go func() {
+			errA <- p.printPackets(ctxA, p.buffer)
+		}()
+		select {
+		case <-firstInitStarted:
+		case <-time.After(fsmWaitTimeout):
+			t.Fatal("first init did not start")
+		}
+		cancelA()
+		if err := requireDone(t, errA); !errors.Is(err, context.Canceled) {
+			t.Fatalf("first print error = %v, want context.Canceled", err)
+		}
+
+		ctxB, cancelB := context.WithCancel(context.Background())
+		defer cancelB()
+		errB := make(chan error, 1)
+		go func() {
+			errB <- p.printPackets(ctxB, p.buffer)
+		}()
+		select {
+		case <-secondStreamStarted:
+		case <-time.After(fsmWaitTimeout):
+			t.Fatal("second print stream did not start")
+		}
+
+		close(releaseFirstInit)
+		time.Sleep(fsmBlockTimeout)
+
+		mu.Lock()
+		streamCount := len(streamJobs)
+		streamJob := streamJobs[0]
+		gotFirstJob := firstJob
+		gotSecondJob := secondJob
+		mu.Unlock()
+		if gotFirstJob == nil || gotSecondJob == nil {
+			t.Fatal("expected both jobs to be recorded")
+		}
+		if streamCount != 1 {
+			t.Fatalf("stream starts = %d, want 1", streamCount)
+		}
+		if streamJob != gotSecondJob {
+			t.Fatal("stream started for a job other than the second job")
+		}
+
+		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventPacketsSent})
+		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventNotificationFinished})
+		if err := requireDone(t, errB); err != nil {
+			t.Fatalf("second print error = %v, want nil", err)
+		}
+	})
+
+	t.Run("stale packet stream event does not affect next print", func(t *testing.T) {
+		p := newFSMTestPrinter(1)
+		staleDone := make(chan struct{})
+		var (
+			mu        sync.Mutex
+			firstJob  *printJob
+			secondJob *printJob
+			starts    int
+		)
+		p.initSequenceHook = func(job *printJob) {
+			p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
+		}
+		p.sendAndWaitHook = func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
+			return append([]byte(nil), expectPrefix...), nil
+		}
+		p.printBufferHook = func(job *printJob, start int) {
+			mu.Lock()
+			starts++
+			call := starts
+			if call == 1 {
+				firstJob = job
+			} else if call == 2 {
+				secondJob = job
+			}
+			mu.Unlock()
+			if call == 1 {
+				go func() {
+					<-staleDone
+					p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent})
+				}()
+			}
+		}
+
+		ctxA, cancelA := context.WithCancel(context.Background())
+		errA := make(chan error, 1)
+		go func() {
+			errA <- p.printPackets(ctxA, p.buffer)
+		}()
+		waitUntil(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return firstJob != nil
+		})
+		cancelA()
+		if err := requireDone(t, errA); !errors.Is(err, context.Canceled) {
+			t.Fatalf("first print error = %v, want context.Canceled", err)
+		}
+
+		ctxB, cancelB := context.WithCancel(context.Background())
+		defer cancelB()
+		errB := make(chan error, 1)
+		go func() {
+			errB <- p.printPackets(ctxB, p.buffer)
+		}()
+		waitUntil(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return secondJob != nil
+		})
+
+		close(staleDone)
+		time.Sleep(fsmBlockTimeout)
+		waitForState(t, p, statePrinting)
+		requireNoDone(t, errB)
+
+		mu.Lock()
+		gotSecondJob := secondJob
+		mu.Unlock()
+		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventPacketsSent})
+		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventNotificationFinished})
+		if err := requireDone(t, errB); err != nil {
+			t.Fatalf("second print error = %v, want nil", err)
 		}
 	})
 }
@@ -441,13 +639,14 @@ func TestNotificationWorker(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := newFSMTestPrinter(1)
+			job := activeTestJob(t, p)
 			notifyCh := make(chan lxd02notification, 1)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			go p.worker(ctx, notifyCh)
 
 			notifyCh <- tc.ntf
-			got := requireEvent(t, p.eventCh, tc.want)
+			got := requireEvent(t, job.eventCh, tc.want)
 			if tc.want == eventNotificationRetransmit && !bytes.Equal(got.data, tc.ntf.data) {
 				t.Fatalf("retransmit data = % x, want % x", got.data, tc.ntf.data)
 			}
@@ -456,7 +655,9 @@ func TestNotificationWorker(t *testing.T) {
 
 	t.Run("no active event receiver does not block worker", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
-		p.eventCh = nil
+		p.stateMu.Lock()
+		p.activeJob = nil
+		p.stateMu.Unlock()
 		notifyCh := make(chan lxd02notification)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -478,4 +679,22 @@ func TestNotificationWorker(t *testing.T) {
 			}
 		}
 	})
+}
+
+func waitUntil(t *testing.T, fn func() bool) {
+	t.Helper()
+
+	deadline := time.After(fsmWaitTimeout)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		if fn() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for condition")
+		case <-tick.C:
+		}
+	}
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -331,7 +331,31 @@ func TestFSM(t *testing.T) {
 		}
 	})
 
-	t.Run("hold during printing cancels stream and pauses", func(t *testing.T) {
+	t.Run("hold during printing pauses stream", func(t *testing.T) {
+		p := newFSMTestPrinter(1)
+		job := activeTestJob(t, p)
+		setFSMState(p, statePrinting)
+		p.stateMu.Lock()
+		job.printSeq = 7
+		job.printStream = 7
+		p.stateMu.Unlock()
+		cancelled := make(chan struct{})
+		var once sync.Once
+		job.printCancel = func() {
+			once.Do(func() { close(cancelled) })
+		}
+
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold})
+
+		select {
+		case <-cancelled:
+		case <-time.After(fsmWaitTimeout):
+			t.Fatal("printCancel was not called")
+		}
+		waitForState(t, p, statePaused)
+	})
+
+	t.Run("packet completion after hold waits for printer completion", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
 		job := activeTestJob(t, p)
 		setFSMState(p, statePrinting)
@@ -354,10 +378,38 @@ func TestFSM(t *testing.T) {
 		}
 		waitForState(t, p, statePaused)
 
-		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: 7}); ok {
-			t.Fatal("stale packet completion after hold was accepted")
+		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: 7}); !ok {
+			t.Fatal("packet completion after hold was ignored")
 		}
+		waitForState(t, p, stateWaitingRetry)
+	})
+
+	t.Run("packet completion before paused retransmit is ignored", func(t *testing.T) {
+		p := newFSMTestPrinter(10)
+		job := activeTestJob(t, p)
+		setFSMState(p, statePrinting)
+		p.stateMu.Lock()
+		job.printSeq = 7
+		job.printStream = 7
+		p.stateMu.Unlock()
+		job.printCancel = func() {}
+		starts := make(chan fsmStreamStart, 1)
+		p.printBufferHook = func(_ *printJob, start int, streamID uint64) {
+			starts <- fsmStreamStart{start: start, streamID: streamID}
+		}
+
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold})
 		waitForState(t, p, statePaused)
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationRetransmit, data: []byte{0x5a, 0x05, 0x00, 0x04}})
+		second := requireStreamStart(t, starts)
+		if second.start != 4 {
+			t.Fatalf("second stream start = %d, want 4", second.start)
+		}
+
+		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: 7}); ok {
+			t.Fatal("stale packet completion after retransmit was accepted")
+		}
+		waitForState(t, p, statePrinting)
 	})
 
 	t.Run("hold while waiting for completion stays waiting", func(t *testing.T) {

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -335,6 +335,10 @@ func TestFSM(t *testing.T) {
 		p := newFSMTestPrinter(1)
 		job := activeTestJob(t, p)
 		setFSMState(p, statePrinting)
+		p.stateMu.Lock()
+		job.printSeq = 7
+		job.printStream = 7
+		p.stateMu.Unlock()
 		cancelled := make(chan struct{})
 		var once sync.Once
 		job.printCancel = func() {
@@ -347,6 +351,11 @@ func TestFSM(t *testing.T) {
 		case <-cancelled:
 		case <-time.After(fsmWaitTimeout):
 			t.Fatal("printCancel was not called")
+		}
+		waitForState(t, p, statePaused)
+
+		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: 7}); ok {
+			t.Fatal("stale packet completion after hold was accepted")
 		}
 		waitForState(t, p, statePaused)
 	})

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -20,6 +20,11 @@ type fsmSendAndWaitCall struct {
 	timeout      time.Duration
 }
 
+type fsmStreamStart struct {
+	start    int
+	streamID uint64
+}
+
 func newFSMTestPrinter(packetCount int) *LXD02 {
 	buffer := make([][]byte, packetCount)
 	for i := range buffer {
@@ -115,6 +120,18 @@ func requireEvent(t *testing.T, eventCh <-chan fsmEvent, want printerEvent) fsmE
 	}
 }
 
+func requireStreamStart(t *testing.T, starts <-chan fsmStreamStart) fsmStreamStart {
+	t.Helper()
+
+	select {
+	case got := <-starts:
+		return got
+	case <-time.After(fsmWaitTimeout):
+		t.Fatal("timed out waiting for print stream start")
+		return fsmStreamStart{}
+	}
+}
+
 func requireNoFinish(t *testing.T, finished <-chan struct{}) {
 	t.Helper()
 
@@ -139,9 +156,9 @@ func TestFSM(t *testing.T) {
 		}
 
 		streamStarts := make(chan int, 1)
-		p.printBufferHook = func(job *printJob, start int) {
+		p.printBufferHook = func(job *printJob, start int, streamID uint64) {
 			streamStarts <- start
-			p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent})
+			p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: streamID})
 		}
 
 		var (
@@ -271,7 +288,7 @@ func TestFSM(t *testing.T) {
 			return wantErr
 		}
 
-		p.printBuffer(job, 0)
+		p.startPrintBuffer(job, 0)
 		err := requireDone(t, job.doneCh)
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("done error = %v, want %v", err, wantErr)
@@ -287,7 +304,7 @@ func TestFSM(t *testing.T) {
 			return append([]byte(nil), expectPrefix...), nil
 		}
 		streamStarted := make(chan struct{})
-		p.printBufferHook = func(*printJob, int) {
+		p.printBufferHook = func(*printJob, int, uint64) {
 			close(streamStarted)
 		}
 
@@ -324,7 +341,7 @@ func TestFSM(t *testing.T) {
 			once.Do(func() { close(cancelled) })
 		}
 
-		p.transition(eventNotificationHold, nil)
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold})
 
 		select {
 		case <-cancelled:
@@ -364,11 +381,11 @@ func TestFSM(t *testing.T) {
 			job := activeTestJob(t, p)
 			setFSMState(p, tc.state)
 			starts := make(chan int, 1)
-			p.printBufferHook = func(_ *printJob, start int) {
+			p.printBufferHook = func(_ *printJob, start int, _ uint64) {
 				starts <- start
 			}
 
-			p.transition(eventNotificationRetransmit, tc.data)
+			p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationRetransmit, data: tc.data})
 
 			waitForState(t, p, statePrinting)
 			select {
@@ -384,13 +401,50 @@ func TestFSM(t *testing.T) {
 		})
 	}
 
+	t.Run("stale packet completion from previous retransmit round is ignored", func(t *testing.T) {
+		p := newFSMTestPrinter(10)
+		job := activeTestJob(t, p)
+		setFSMState(p, statePrinting)
+
+		starts := make(chan fsmStreamStart, 2)
+		p.printBufferHook = func(_ *printJob, start int, streamID uint64) {
+			starts <- fsmStreamStart{start: start, streamID: streamID}
+		}
+
+		p.startPrintBuffer(job, 0)
+		first := requireStreamStart(t, starts)
+		if first.start != 0 {
+			t.Fatalf("first stream start = %d, want 0", first.start)
+		}
+
+		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationRetransmit, data: []byte{0x5a, 0x05, 0x00, 0x04}})
+		second := requireStreamStart(t, starts)
+		if second.start != 4 {
+			t.Fatalf("second stream start = %d, want 4", second.start)
+		}
+		if second.streamID == first.streamID {
+			t.Fatal("retransmit did not create a new stream ID")
+		}
+
+		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: first.streamID}); ok {
+			t.Fatal("stale packet completion was accepted")
+		}
+		waitForState(t, p, statePrinting)
+		requireNoDone(t, job.doneCh)
+
+		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: second.streamID}); !ok {
+			t.Fatal("current packet completion was ignored")
+		}
+		waitForState(t, p, stateWaitingRetry)
+	})
+
 	t.Run("duplicate error and cancel complete once without blocking", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
 		job := activeTestJob(t, p)
 		setFSMState(p, statePrinting)
 
-		p.transition(eventError, nil)
-		p.transition(eventCancel, nil)
+		p.dispatchJobEvent(job, fsmEvent{kind: eventError})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventCancel})
 
 		if err := requireDone(t, job.doneCh); !errors.Is(err, errPrintFailed) {
 			t.Fatalf("done error = %v, want %v", err, errPrintFailed)
@@ -405,7 +459,7 @@ func TestFSM(t *testing.T) {
 		finished := make(chan struct{})
 
 		go func() {
-			p.transition(eventCancel, nil)
+			p.dispatchJobEvent(activeTestJob(t, p), fsmEvent{kind: eventCancel})
 			close(finished)
 		}()
 
@@ -445,10 +499,12 @@ func TestFSM(t *testing.T) {
 			secondJob  *printJob
 			initCalls  int
 			streamJobs []*printJob
+			secondID   uint64
 		)
 		firstInitStarted := make(chan struct{})
 		releaseFirstInit := make(chan struct{})
 		secondStreamStarted := make(chan struct{})
+		var secondStreamOnce sync.Once
 		p.initSequenceHook = func(job *printJob) {
 			mu.Lock()
 			initCalls++
@@ -471,14 +527,17 @@ func TestFSM(t *testing.T) {
 		p.sendAndWaitHook = func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
 			return append([]byte(nil), expectPrefix...), nil
 		}
-		p.printBufferHook = func(job *printJob, start int) {
+		p.printBufferHook = func(job *printJob, start int, streamID uint64) {
 			mu.Lock()
 			streamJobs = append(streamJobs, job)
+			secondID = streamID
 			mu.Unlock()
 			if start != 0 {
 				t.Errorf("stream start = %d, want 0", start)
 			}
-			close(secondStreamStarted)
+			secondStreamOnce.Do(func() {
+				close(secondStreamStarted)
+			})
 		}
 
 		ctxA, cancelA := context.WithCancel(context.Background())
@@ -516,6 +575,7 @@ func TestFSM(t *testing.T) {
 		streamJob := streamJobs[0]
 		gotFirstJob := firstJob
 		gotSecondJob := secondJob
+		gotSecondID := secondID
 		mu.Unlock()
 		if gotFirstJob == nil || gotSecondJob == nil {
 			t.Fatal("expected both jobs to be recorded")
@@ -527,7 +587,7 @@ func TestFSM(t *testing.T) {
 			t.Fatal("stream started for a job other than the second job")
 		}
 
-		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventPacketsSent})
+		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventPacketsSent, streamID: gotSecondID})
 		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventNotificationFinished})
 		if err := requireDone(t, errB); err != nil {
 			t.Fatalf("second print error = %v, want nil", err)
@@ -542,6 +602,7 @@ func TestFSM(t *testing.T) {
 			firstJob  *printJob
 			secondJob *printJob
 			starts    int
+			secondID  uint64
 		)
 		p.initSequenceHook = func(job *printJob) {
 			p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
@@ -549,7 +610,7 @@ func TestFSM(t *testing.T) {
 		p.sendAndWaitHook = func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
 			return append([]byte(nil), expectPrefix...), nil
 		}
-		p.printBufferHook = func(job *printJob, start int) {
+		p.printBufferHook = func(job *printJob, start int, streamID uint64) {
 			mu.Lock()
 			starts++
 			call := starts
@@ -557,12 +618,13 @@ func TestFSM(t *testing.T) {
 				firstJob = job
 			} else if call == 2 {
 				secondJob = job
+				secondID = streamID
 			}
 			mu.Unlock()
 			if call == 1 {
 				go func() {
 					<-staleDone
-					p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent})
+					p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: streamID})
 				}()
 			}
 		}
@@ -601,8 +663,9 @@ func TestFSM(t *testing.T) {
 
 		mu.Lock()
 		gotSecondJob := secondJob
+		gotSecondID := secondID
 		mu.Unlock()
-		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventPacketsSent})
+		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventPacketsSent, streamID: gotSecondID})
 		p.dispatchJobEvent(gotSecondJob, fsmEvent{kind: eventNotificationFinished})
 		if err := requireDone(t, errB); err != nil {
 			t.Fatalf("second print error = %v, want nil", err)

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1,10 +1,9 @@
 package thermoprint
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"os"
-	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -13,8 +12,6 @@ import (
 const (
 	fsmWaitTimeout  = 500 * time.Millisecond
 	fsmBlockTimeout = 50 * time.Millisecond
-
-	nilEventChWorkerHelperEnv = "THERMOPRINT_NIL_EVENTCH_WORKER_HELPER"
 )
 
 type fsmSendAndWaitCall struct {
@@ -28,15 +25,28 @@ func newFSMTestPrinter(packetCount int) *LXD02 {
 	for i := range buffer {
 		buffer[i] = []byte{byte(i)}
 	}
-	return &LXD02{
+	p := &LXD02{
 		buffer:  buffer,
 		state:   stateIdle,
 		eventCh: make(chan fsmEvent, 20),
-		doneCh:  make(chan struct{}, 2),
+		doneCh:  make(chan error, 2),
 		options: printOptions{
 			printInterval: time.Millisecond,
 		},
 	}
+	p.printFSM = p.newPrintFSM(stateIdle)
+	return p
+}
+
+func setFSMState(p *LXD02, state printerState) {
+	p.stateMu.Lock()
+	p.state = state
+	if p.printFSM == nil {
+		p.printFSM = p.newPrintFSM(state)
+	} else {
+		p.printFSM.SetState(state.String())
+	}
+	p.stateMu.Unlock()
 }
 
 func waitForState(t *testing.T, p *LXD02, want printerState) {
@@ -62,22 +72,24 @@ func waitForState(t *testing.T, p *LXD02, want printerState) {
 	}
 }
 
-func requireDone(t *testing.T, doneCh <-chan struct{}) {
+func requireDone(t *testing.T, doneCh <-chan error) error {
 	t.Helper()
 
 	select {
-	case <-doneCh:
+	case err := <-doneCh:
+		return err
 	case <-time.After(fsmWaitTimeout):
 		t.Fatal("timed out waiting for done signal")
+		return nil
 	}
 }
 
-func requireNoDone(t *testing.T, doneCh <-chan struct{}) {
+func requireNoDone(t *testing.T, doneCh <-chan error) {
 	t.Helper()
 
 	select {
-	case <-doneCh:
-		t.Fatal("unexpected done signal")
+	case err := <-doneCh:
+		t.Fatalf("unexpected done signal: %v", err)
 	case <-time.After(fsmBlockTimeout):
 	}
 }
@@ -107,23 +119,23 @@ func requireNoFinish(t *testing.T, finished <-chan struct{}) {
 	}
 }
 
-func TestFSMCurrent(t *testing.T) {
+func TestFSM(t *testing.T) {
 	t.Run("successful flow", func(t *testing.T) {
 		p := newFSMTestPrinter(3)
-		p.doneCh = make(chan struct{})
+		p.doneCh = make(chan error, 1)
 
 		initCalled := make(chan struct{})
 		releaseInit := make(chan struct{})
 		p.initSequenceHook = func() {
 			close(initCalled)
 			<-releaseInit
-			p.eventCh <- fsmEvent{kind: eventInitComplete}
+			p.emitEvent(fsmEvent{kind: eventInitComplete})
 		}
 
 		streamStarts := make(chan int, 1)
 		p.printBufferHook = func(start int) {
 			streamStarts <- start
-			p.eventCh <- fsmEvent{kind: eventNotificationFinished}
+			p.emitEvent(fsmEvent{kind: eventPacketsSent})
 		}
 
 		var (
@@ -145,7 +157,7 @@ func TestFSMCurrent(t *testing.T) {
 		defer cancel()
 		go p.runFSM(ctx)
 
-		p.eventCh <- fsmEvent{kind: eventStart}
+		p.emitEvent(fsmEvent{kind: eventStart})
 
 		select {
 		case <-initCalled:
@@ -169,13 +181,15 @@ func TestFSMCurrent(t *testing.T) {
 		if len(calls) != 1 {
 			t.Fatalf("sendAndWait calls after begin = %d, want 1", len(calls))
 		}
-		if got, want := calls[0].data, []byte{0x5a, 0x04, 0x00, 0x03, 0x00, 0x00}; !bytesEqual(got, want) {
+		if got, want := calls[0].data, []byte{0x5a, 0x04, 0x00, 0x03, 0x00, 0x00}; !bytes.Equal(got, want) {
 			t.Fatalf("begin command = % x, want % x", got, want)
 		}
 		callsMu.Unlock()
 
-		p.eventCh <- fsmEvent{kind: eventNotificationFinished}
-		requireDone(t, p.doneCh)
+		p.emitEvent(fsmEvent{kind: eventNotificationFinished})
+		if err := requireDone(t, p.doneCh); err != nil {
+			t.Fatalf("done error = %v, want nil", err)
+		}
 		waitForState(t, p, stateCompleted)
 
 		callsMu.Lock()
@@ -183,71 +197,124 @@ func TestFSMCurrent(t *testing.T) {
 		if len(calls) != 2 {
 			t.Fatalf("sendAndWait calls after final = %d, want 2", len(calls))
 		}
-		if got, want := calls[1].data, []byte{0x5a, 0x04, 0x00, 0x03, 0x01, 0x00}; !bytesEqual(got, want) {
+		if got, want := calls[1].data, []byte{0x5a, 0x04, 0x00, 0x03, 0x01, 0x00}; !bytes.Equal(got, want) {
 			t.Fatalf("final command = % x, want % x", got, want)
 		}
 	})
 
-	t.Run("init failure transitions and signals failed", func(t *testing.T) {
+	t.Run("init failure transitions and returns error", func(t *testing.T) {
+		wantErr := errors.New("init failed")
 		p := newFSMTestPrinter(1)
 		p.initSequenceHook = func() {
-			p.eventCh <- fsmEvent{kind: eventError}
+			p.emitEvent(fsmEvent{kind: eventError, err: wantErr})
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go p.runFSM(ctx)
 
-		p.eventCh <- fsmEvent{kind: eventStart}
-		requireDone(t, p.doneCh)
+		p.emitEvent(fsmEvent{kind: eventStart})
+		if err := requireDone(t, p.doneCh); !errors.Is(err, wantErr) {
+			t.Fatalf("done error = %v, want %v", err, wantErr)
+		}
 		waitForState(t, p, stateFailed)
 	})
 
-	t.Run("begin command failure transitions and signals failed", func(t *testing.T) {
+	t.Run("begin command failure transitions and returns error", func(t *testing.T) {
+		wantErr := errors.New("begin failed")
 		p := newFSMTestPrinter(1)
 		p.initSequenceHook = func() {
-			p.eventCh <- fsmEvent{kind: eventInitComplete}
+			p.emitEvent(fsmEvent{kind: eventInitComplete})
 		}
 		p.sendAndWaitHook = func([]byte, []byte, time.Duration) ([]byte, error) {
-			return nil, errors.New("begin failed")
+			return nil, wantErr
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go p.runFSM(ctx)
 
-		p.eventCh <- fsmEvent{kind: eventStart}
-		requireDone(t, p.doneCh)
+		p.emitEvent(fsmEvent{kind: eventStart})
+		err := requireDone(t, p.doneCh)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("done error = %v, want %v", err, wantErr)
+		}
 		waitForState(t, p, stateFailed)
 	})
 
-	t.Run("final command failure emits error after completed without done", func(t *testing.T) {
+	t.Run("final command failure transitions and returns error", func(t *testing.T) {
+		wantErr := errors.New("final failed")
 		p := newFSMTestPrinter(1)
-		p.state = stateWaitingRetry
+		setFSMState(p, stateWaitingRetry)
 		p.sendAndWaitHook = func([]byte, []byte, time.Duration) ([]byte, error) {
-			return nil, errors.New("final failed")
+			return nil, wantErr
 		}
 
-		p.transition(eventNotificationFinished, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go p.runFSM(ctx)
 
-		waitForState(t, p, stateCompleted)
-		requireEvent(t, p.eventCh, eventError)
-		requireNoDone(t, p.doneCh)
+		p.emitEvent(fsmEvent{kind: eventNotificationFinished})
+		err := requireDone(t, p.doneCh)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("done error = %v, want %v", err, wantErr)
+		}
+		waitForState(t, p, stateFailed)
 	})
 
 	t.Run("packet send failure emits error", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
+		wantErr := errors.New("packet failed")
 		p.sendPacketHook = func([]byte) error {
-			return errors.New("packet failed")
+			return wantErr
 		}
 
 		p.printBuffer(0)
-		requireEvent(t, p.eventCh, eventError)
+		got := requireEvent(t, p.eventCh, eventError)
+		if !errors.Is(got.err, wantErr) {
+			t.Fatalf("event error = %v, want %v", got.err, wantErr)
+		}
+	})
+
+	t.Run("context cancellation returns cancellation error", func(t *testing.T) {
+		p := newFSMTestPrinter(1)
+		p.initSequenceHook = func() {
+			p.emitEvent(fsmEvent{kind: eventInitComplete})
+		}
+		p.sendAndWaitHook = func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error) {
+			return append([]byte(nil), expectPrefix...), nil
+		}
+		streamStarted := make(chan struct{})
+		p.printBufferHook = func(int) {
+			close(streamStarted)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- p.printPackets(ctx, p.buffer)
+		}()
+
+		select {
+		case <-streamStarted:
+		case <-time.After(fsmWaitTimeout):
+			t.Fatal("print stream was not started")
+		}
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("printPackets error = %v, want context.Canceled", err)
+			}
+		case <-time.After(fsmWaitTimeout):
+			t.Fatal("printPackets did not return after cancellation")
+		}
 	})
 
 	t.Run("hold during printing cancels stream and pauses", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
-		p.state = statePrinting
+		setFSMState(p, statePrinting)
 		cancelled := make(chan struct{})
 		var once sync.Once
 		p.printCancel = func() {
@@ -291,7 +358,7 @@ func TestFSMCurrent(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := newFSMTestPrinter(10)
-			p.state = tc.state
+			setFSMState(p, tc.state)
 			starts := make(chan int, 1)
 			p.printBufferHook = func(start int) {
 				starts <- start
@@ -311,44 +378,25 @@ func TestFSMCurrent(t *testing.T) {
 		})
 	}
 
-	t.Run("context cancellation transitions and signals failed", func(t *testing.T) {
+	t.Run("duplicate error and cancel complete once without blocking", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
-		p.state = statePrinting
+		setFSMState(p, statePrinting)
+		p.doneCh = make(chan error, 2)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		go p.runFSM(ctx)
-		cancel()
+		p.transition(eventError, nil)
+		p.transition(eventCancel, nil)
 
-		requireDone(t, p.doneCh)
+		if err := requireDone(t, p.doneCh); !errors.Is(err, errPrintFailed) {
+			t.Fatalf("done error = %v, want %v", err, errPrintFailed)
+		}
+		requireNoDone(t, p.doneCh)
 		waitForState(t, p, stateFailed)
 	})
 
-	t.Run("error while printing blocks without a second done receiver", func(t *testing.T) {
+	t.Run("cancel after failed does not block without a done receiver", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
-		p.state = statePrinting
-		p.doneCh = make(chan struct{})
-		finished := make(chan struct{})
-
-		go func() {
-			p.transition(eventError, nil)
-			close(finished)
-		}()
-
-		requireDone(t, p.doneCh)
-		requireNoFinish(t, finished)
-
-		requireDone(t, p.doneCh)
-		select {
-		case <-finished:
-		case <-time.After(fsmWaitTimeout):
-			t.Fatal("transition did not finish after second done receiver")
-		}
-	})
-
-	t.Run("cancel after failed blocks without a done receiver", func(t *testing.T) {
-		p := newFSMTestPrinter(1)
-		p.state = stateFailed
-		p.doneCh = make(chan struct{})
+		setFSMState(p, stateFailed)
+		p.doneCh = make(chan error)
 		finished := make(chan struct{})
 
 		go func() {
@@ -356,22 +404,15 @@ func TestFSMCurrent(t *testing.T) {
 			close(finished)
 		}()
 
-		requireNoFinish(t, finished)
-		requireDone(t, p.doneCh)
 		select {
 		case <-finished:
 		case <-time.After(fsmWaitTimeout):
-			t.Fatal("transition did not finish after done receiver")
+			t.Fatal("transition blocked without a done receiver")
 		}
 	})
 }
 
-func TestNotificationWorkerCurrent(t *testing.T) {
-	if os.Getenv(nilEventChWorkerHelperEnv) == "1" {
-		runNilEventChWorkerBlockHelper(t)
-		return
-	}
-
+func TestNotificationWorker(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ntf  lxd02notification
@@ -407,101 +448,34 @@ func TestNotificationWorkerCurrent(t *testing.T) {
 
 			notifyCh <- tc.ntf
 			got := requireEvent(t, p.eventCh, tc.want)
-			if tc.want == eventNotificationRetransmit && !bytesEqual(got.data, tc.ntf.data) {
+			if tc.want == eventNotificationRetransmit && !bytes.Equal(got.data, tc.ntf.data) {
 				t.Fatalf("retransmit data = % x, want % x", got.data, tc.ntf.data)
 			}
 		})
 	}
 
-	t.Run("no active event receiver blocks worker", func(t *testing.T) {
+	t.Run("no active event receiver does not block worker", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
-		p.eventCh = make(chan fsmEvent)
+		p.eventCh = nil
 		notifyCh := make(chan lxd02notification)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go p.worker(ctx, notifyCh)
 
-		firstSent := make(chan struct{})
-		go func() {
-			notifyCh <- lxd02notification{prefix: ntHold, data: []byte{0x5a, 0x08}}
-			close(firstSent)
-		}()
-		select {
-		case <-firstSent:
-		case <-time.After(fsmWaitTimeout):
-			t.Fatal("worker did not receive first notification")
+		for _, ntf := range []lxd02notification{
+			{prefix: ntHold, data: []byte{0x5a, 0x08}},
+			{prefix: ntFinished, data: []byte{0x5a, 0x06}},
+		} {
+			sent := make(chan struct{})
+			go func() {
+				notifyCh <- ntf
+				close(sent)
+			}()
+			select {
+			case <-sent:
+			case <-time.After(fsmWaitTimeout):
+				t.Fatal("worker blocked while no print was active")
+			}
 		}
-
-		secondSent := make(chan struct{})
-		go func() {
-			notifyCh <- lxd02notification{prefix: ntFinished, data: []byte{0x5a, 0x06}}
-			close(secondSent)
-		}()
-		requireNoFinish(t, secondSent)
-
-		requireEvent(t, p.eventCh, eventNotificationHold)
-		select {
-		case <-secondSent:
-		case <-time.After(fsmWaitTimeout):
-			t.Fatal("worker did not receive second notification after event receiver attached")
-		}
-		requireEvent(t, p.eventCh, eventNotificationFinished)
 	})
-
-	t.Run("nil event channel blocks worker", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), fsmWaitTimeout)
-		defer cancel()
-
-		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestNotificationWorkerCurrent$")
-		cmd.Env = append(os.Environ(), nilEventChWorkerHelperEnv+"=1")
-		err := cmd.Run()
-		if ctx.Err() == context.DeadlineExceeded {
-			return
-		}
-		if err != nil {
-			t.Fatalf("helper exited before documenting nil event channel block: %v", err)
-		}
-		t.Fatal("helper exited successfully; want worker blocked on nil event channel")
-	})
-}
-
-func runNilEventChWorkerBlockHelper(t *testing.T) {
-	p := newFSMTestPrinter(1)
-	p.eventCh = nil
-	notifyCh := make(chan lxd02notification)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go p.worker(ctx, notifyCh)
-
-	firstSent := make(chan struct{})
-	go func() {
-		notifyCh <- lxd02notification{prefix: ntHold, data: []byte{0x5a, 0x08}}
-		close(firstSent)
-	}()
-	select {
-	case <-firstSent:
-	case <-time.After(fsmWaitTimeout):
-		t.Fatal("worker did not receive first notification")
-	}
-
-	secondSent := make(chan struct{})
-	go func() {
-		notifyCh <- lxd02notification{prefix: ntFinished, data: []byte{0x5a, 0x06}}
-		close(secondSent)
-	}()
-	requireNoFinish(t, secondSent)
-
-	select {}
-}
-
-func bytesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -331,7 +331,7 @@ func TestFSM(t *testing.T) {
 		}
 	})
 
-	t.Run("hold during printing pauses stream", func(t *testing.T) {
+	t.Run("hold during printing does not stop stream", func(t *testing.T) {
 		p := newFSMTestPrinter(1)
 		job := activeTestJob(t, p)
 		setFSMState(p, statePrinting)
@@ -340,19 +340,14 @@ func TestFSM(t *testing.T) {
 		job.printStream = 7
 		p.stateMu.Unlock()
 		cancelled := make(chan struct{})
-		var once sync.Once
 		job.printCancel = func() {
-			once.Do(func() { close(cancelled) })
+			close(cancelled)
 		}
 
 		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold})
 
-		select {
-		case <-cancelled:
-		case <-time.After(fsmWaitTimeout):
-			t.Fatal("printCancel was not called")
-		}
 		waitForState(t, p, statePaused)
+		requireNoFinish(t, cancelled)
 	})
 
 	t.Run("packet completion after hold waits for printer completion", func(t *testing.T) {
@@ -363,19 +358,8 @@ func TestFSM(t *testing.T) {
 		job.printSeq = 7
 		job.printStream = 7
 		p.stateMu.Unlock()
-		cancelled := make(chan struct{})
-		var once sync.Once
-		job.printCancel = func() {
-			once.Do(func() { close(cancelled) })
-		}
 
 		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold})
-
-		select {
-		case <-cancelled:
-		case <-time.After(fsmWaitTimeout):
-			t.Fatal("printCancel was not called")
-		}
 		waitForState(t, p, statePaused)
 
 		if ok := p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: 7}); !ok {
@@ -392,7 +376,11 @@ func TestFSM(t *testing.T) {
 		job.printSeq = 7
 		job.printStream = 7
 		p.stateMu.Unlock()
-		job.printCancel = func() {}
+		cancelled := make(chan struct{})
+		var cancelOnce sync.Once
+		job.printCancel = func() {
+			cancelOnce.Do(func() { close(cancelled) })
+		}
 		starts := make(chan fsmStreamStart, 1)
 		p.printBufferHook = func(_ *printJob, start int, streamID uint64) {
 			starts <- fsmStreamStart{start: start, streamID: streamID}
@@ -400,7 +388,13 @@ func TestFSM(t *testing.T) {
 
 		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationHold})
 		waitForState(t, p, statePaused)
+		requireNoFinish(t, cancelled)
 		p.dispatchJobEvent(job, fsmEvent{kind: eventNotificationRetransmit, data: []byte{0x5a, 0x05, 0x00, 0x04}})
+		select {
+		case <-cancelled:
+		case <-time.After(fsmWaitTimeout):
+			t.Fatal("printCancel was not called on retransmit")
+		}
 		second := requireStreamStart(t, starts)
 		if second.start != 4 {
 			t.Fatalf("second stream start = %d, want 4", second.start)

--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,5 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+tool golang.org/x/tools/cmd/stringer

--- a/ippsrv/job.go
+++ b/ippsrv/job.go
@@ -38,7 +38,7 @@ type JobID int32
 // JobState represents the state of a job.
 // https://datatracker.ietf.org/doc/html/rfc2911#section-4.3.7
 //
-//go:generate stringer -trimprefix Job -type JobState
+//go:generate go tool stringer -trimprefix Job -type JobState
 type JobState int32
 
 const (

--- a/ippsrv/jobstate_string.go
+++ b/ippsrv/jobstate_string.go
@@ -22,9 +22,9 @@ const _JobState_name = "PendingPendingHeldProcessingProcessingStoppedCancelledAb
 var _JobState_index = [...]uint8{0, 7, 18, 28, 45, 54, 61, 70}
 
 func (i JobState) String() string {
-	i -= 3
-	if i < 0 || i >= JobState(len(_JobState_index)-1) {
-		return "JobState(" + strconv.FormatInt(int64(i+3), 10) + ")"
+	idx := int(i) - 3
+	if i < 3 || idx >= len(_JobState_index)-1 {
+		return "JobState(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _JobState_name[_JobState_index[i]:_JobState_index[i+1]]
+	return _JobState_name[_JobState_index[idx]:_JobState_index[idx+1]]
 }

--- a/lx-d02.go
+++ b/lx-d02.go
@@ -70,7 +70,7 @@ type LXD02 struct {
 
 	initSequenceHook func(job *printJob)
 	sendAndWaitHook  func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error)
-	printBufferHook  func(job *printJob, start int)
+	printBufferHook  func(job *printJob, start int, streamID uint64)
 	sendPacketHook   func(data []byte) error
 }
 
@@ -444,12 +444,20 @@ func (p *LXD02) printPackets(ctx context.Context, packets [][]byte) error {
 		slog.Info("print completed successfully")
 		return nil
 	case <-ctx.Done():
-		p.dispatchJobEvent(job, fsmEvent{kind: eventCancel, err: ctx.Err()})
 		select {
 		case err := <-job.doneCh:
 			if err != nil {
 				return err
 			}
+			slog.Info("print completed successfully")
+			return nil
+		default:
+		}
+
+		p.dispatchJobEvent(job, fsmEvent{kind: eventCancel, err: ctx.Err()})
+		select {
+		case err := <-job.doneCh:
+			return err
 		default:
 		}
 		return ctx.Err()
@@ -487,9 +495,9 @@ var errBufferEmpty = errors.New("buffer is empty")
 
 // printBuffer sends the buffer to printer starting from
 // packet n.
-func (p *LXD02) printBuffer(job *printJob, start int) {
+func (p *LXD02) printBuffer(job *printJob, start int, streamID uint64) {
 	if len(p.buffer) == 0 || start >= len(p.buffer) {
-		p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: errBufferEmpty})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: errBufferEmpty, streamID: streamID})
 		return
 	}
 
@@ -513,13 +521,13 @@ func (p *LXD02) printBuffer(job *printJob, start int) {
 				err := p.sendPacket(p.buffer[i])
 				if err != nil {
 					slog.Error("Failed to send packet", "packet", i, "error", err)
-					p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: fmt.Errorf("send packet %d: %w", i, err)})
+					p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: fmt.Errorf("send packet %d: %w", i, err), streamID: streamID})
 					return
 				}
 			}
 		}
 
-		p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent, streamID: streamID})
 	}()
 }
 

--- a/lx-d02.go
+++ b/lx-d02.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/image/font"
 	"tinygo.org/x/bluetooth"
 
-	"github.com/looplab/fsm"
 	"github.com/rusq/thermoprint/bitmap"
 )
 
@@ -59,13 +58,9 @@ type LXD02 struct {
 	buffer     [][]byte
 	rasteriser Rasteriser // Interface for rasterizing images
 
-	stateMu     sync.Mutex
-	state       printerState
-	eventCh     chan fsmEvent
-	doneCh      chan error
-	doneOnce    sync.Once
-	printCancel context.CancelFunc
-	printFSM    *fsm.FSM
+	stateMu   sync.Mutex
+	state     printerState
+	activeJob *printJob
 
 	responseMu    sync.Mutex
 	waitingPrefix []byte
@@ -73,9 +68,9 @@ type LXD02 struct {
 
 	options printOptions
 
-	initSequenceHook func()
+	initSequenceHook func(job *printJob)
 	sendAndWaitHook  func(data []byte, expectPrefix []byte, timeout time.Duration) ([]byte, error)
-	printBufferHook  func(start int)
+	printBufferHook  func(job *printJob, start int)
 	sendPacketHook   func(data []byte) error
 }
 
@@ -421,49 +416,37 @@ func (p *LXD02) PrintRAW(ctx context.Context, data [][]byte) error {
 func (p *LXD02) printPackets(ctx context.Context, packets [][]byte) error {
 	p.loadBuffer(packets)
 
-	doneCh := make(chan error, 1)
-	eventCh := make(chan fsmEvent, 10)
+	job := p.newPrintJob(context.Background())
 	p.stateMu.Lock()
-	p.doneCh = doneCh
-	p.doneOnce = sync.Once{}
-	p.eventCh = eventCh
-	p.printCancel = nil
+	p.activeJob = job
 	p.state = stateIdle
-	p.printFSM = p.newPrintFSM(stateIdle)
 	p.stateMu.Unlock()
 
-	// pctx is the context for the FSM, it will be cancelled when the
-	// print job is done or if the context is cancelled.  It will stop
-	// the FSM goroutine.
-	pctx, cancel := context.WithCancel(context.Background())
 	defer func() {
-		cancel()
-		p.cancelPrintBuffer()
+		job.cancel()
+		p.cancelPrintBuffer(job)
 		p.stateMu.Lock()
-		if p.eventCh == eventCh {
-			p.eventCh = nil
-			p.doneCh = nil
-			p.printFSM = nil
-			p.printCancel = nil
+		if p.activeJob == job {
+			p.activeJob = nil
 		}
 		p.stateMu.Unlock()
 	}()
 
-	go p.runFSM(pctx)
+	go p.runFSM(job)
 
-	p.emitEvent(fsmEvent{kind: eventStart})
+	p.dispatchJobEvent(job, fsmEvent{kind: eventStart})
 
 	select {
-	case err := <-doneCh:
+	case err := <-job.doneCh:
 		if err != nil {
 			return err
 		}
 		slog.Info("print completed successfully")
 		return nil
 	case <-ctx.Done():
-		p.transitionEvent(fsmEvent{kind: eventCancel, err: ctx.Err()})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventCancel, err: ctx.Err()})
 		select {
-		case err := <-doneCh:
+		case err := <-job.doneCh:
 			if err != nil {
 				return err
 			}
@@ -504,15 +487,15 @@ var errBufferEmpty = errors.New("buffer is empty")
 
 // printBuffer sends the buffer to printer starting from
 // packet n.
-func (p *LXD02) printBuffer(start int) {
+func (p *LXD02) printBuffer(job *printJob, start int) {
 	if len(p.buffer) == 0 || start >= len(p.buffer) {
-		p.emitEvent(fsmEvent{kind: eventError, err: errBufferEmpty})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: errBufferEmpty})
 		return
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	p.stateMu.Lock()
-	p.printCancel = cancel
+	job.printCancel = cancel
 	p.stateMu.Unlock()
 
 	go func() {
@@ -530,13 +513,13 @@ func (p *LXD02) printBuffer(start int) {
 				err := p.sendPacket(p.buffer[i])
 				if err != nil {
 					slog.Error("Failed to send packet", "packet", i, "error", err)
-					p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send packet %d: %w", i, err)})
+					p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: fmt.Errorf("send packet %d: %w", i, err)})
 					return
 				}
 			}
 		}
 
-		p.emitEvent(fsmEvent{kind: eventPacketsSent})
+		p.dispatchJobEvent(job, fsmEvent{kind: eventPacketsSent})
 	}()
 }
 
@@ -551,7 +534,7 @@ const (
 	minEnergy, maxEnergy = 1, 6
 )
 
-func (p *LXD02) sendInitSequence() {
+func (p *LXD02) sendInitSequence(job *printJob) {
 	initSeq := [][]byte{
 		{0x5a, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		{0x5a, 0x0a, 0xB5, 0x7C, 0x4C, 0xB8, 0xAE, 0x70, 0x51, 0xE6, 0xD3, 0x06},
@@ -562,12 +545,12 @@ func (p *LXD02) sendInitSequence() {
 		expectPrefix := cmd[:2]
 		resp, err := p.sendAndWait(cmd, expectPrefix, responseTimeout)
 		if err != nil {
-			p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send init command % x: %w", expectPrefix, err)})
+			p.dispatchJobEvent(job, fsmEvent{kind: eventError, err: fmt.Errorf("send init command % x: %w", expectPrefix, err)})
 			return
 		}
 		slog.Debug("init ack", "prefix", fmt.Sprintf("% x", expectPrefix), "response", fmt.Sprintf("% x", resp))
 	}
-	p.emitEvent(fsmEvent{kind: eventInitComplete})
+	p.dispatchJobEvent(job, fsmEvent{kind: eventInitComplete})
 }
 
 func extractRetryPacketIndex(data []byte) int {

--- a/lx-d02.go
+++ b/lx-d02.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/image/font"
 	"tinygo.org/x/bluetooth"
 
+	"github.com/looplab/fsm"
 	"github.com/rusq/thermoprint/bitmap"
 )
 
@@ -61,8 +62,10 @@ type LXD02 struct {
 	stateMu     sync.Mutex
 	state       printerState
 	eventCh     chan fsmEvent
-	doneCh      chan struct{}
+	doneCh      chan error
+	doneOnce    sync.Once
 	printCancel context.CancelFunc
+	printFSM    *fsm.FSM
 
 	responseMu    sync.Mutex
 	waitingPrefix []byte
@@ -318,7 +321,11 @@ func (p *LXD02) worker(ctx context.Context, notifyCh <-chan lxd02notification) {
 		case <-ctx.Done():
 			slog.Debug("Worker context done, exiting")
 			return
-		case ntf := <-notifyCh:
+		case ntf, ok := <-notifyCh:
+			if !ok {
+				slog.Debug("notification channel closed, worker exiting")
+				return
+			}
 			lg := slog.With("instruction", ntf.prefix, "data", fmt.Sprintf("% x", ntf.data))
 			lg.DebugContext(ctx, "received notification")
 			switch ntf.prefix {
@@ -336,14 +343,14 @@ func (p *LXD02) worker(ctx context.Context, notifyCh <-chan lxd02notification) {
 				}
 				if st.NoPaper {
 					slog.ErrorContext(ctx, "no paper")
-					p.eventCh <- fsmEvent{kind: eventError}
+					p.routeNotificationEvent(fsmEvent{kind: eventError, err: errors.New("printer reported no paper")})
 				}
 			case ntHold:
-				p.eventCh <- fsmEvent{kind: eventNotificationHold}
+				p.routeNotificationEvent(fsmEvent{kind: eventNotificationHold})
 			case ntRetransmit:
-				p.eventCh <- fsmEvent{kind: eventNotificationRetransmit, data: ntf.data}
+				p.routeNotificationEvent(fsmEvent{kind: eventNotificationRetransmit, data: ntf.data})
 			case ntFinished:
-				p.eventCh <- fsmEvent{kind: eventNotificationFinished}
+				p.routeNotificationEvent(fsmEvent{kind: eventNotificationFinished})
 			default:
 				lg.WarnContext(ctx, "unsupported command")
 			}
@@ -412,27 +419,57 @@ func (p *LXD02) PrintRAW(ctx context.Context, data [][]byte) error {
 // printPackets is the low level routine that starts the FSM and sends the
 // encoded image data to the printer.
 func (p *LXD02) printPackets(ctx context.Context, packets [][]byte) error {
-	p.doneCh = make(chan struct{})
-	p.eventCh = make(chan fsmEvent, 10)
 	p.loadBuffer(packets)
+
+	doneCh := make(chan error, 1)
+	eventCh := make(chan fsmEvent, 10)
+	p.stateMu.Lock()
+	p.doneCh = doneCh
+	p.doneOnce = sync.Once{}
+	p.eventCh = eventCh
+	p.printCancel = nil
+	p.state = stateIdle
+	p.printFSM = p.newPrintFSM(stateIdle)
+	p.stateMu.Unlock()
 
 	// pctx is the context for the FSM, it will be cancelled when the
 	// print job is done or if the context is cancelled.  It will stop
 	// the FSM goroutine.
-	pctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	pctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		p.cancelPrintBuffer()
+		p.stateMu.Lock()
+		if p.eventCh == eventCh {
+			p.eventCh = nil
+			p.doneCh = nil
+			p.printFSM = nil
+			p.printCancel = nil
+		}
+		p.stateMu.Unlock()
+	}()
 
 	go p.runFSM(pctx)
 
-	p.eventCh <- fsmEvent{kind: eventStart}
+	p.emitEvent(fsmEvent{kind: eventStart})
 
 	select {
-	case <-p.doneCh:
+	case err := <-doneCh:
+		if err != nil {
+			return err
+		}
 		slog.Info("print completed successfully")
 		return nil
 	case <-ctx.Done():
-		p.eventCh <- fsmEvent{kind: eventCancel}
-		return errors.New("print job timed out or cancelled")
+		p.transitionEvent(fsmEvent{kind: eventCancel, err: ctx.Err()})
+		select {
+		case err := <-doneCh:
+			if err != nil {
+				return err
+			}
+		default:
+		}
+		return ctx.Err()
 	}
 }
 
@@ -469,12 +506,14 @@ var errBufferEmpty = errors.New("buffer is empty")
 // packet n.
 func (p *LXD02) printBuffer(start int) {
 	if len(p.buffer) == 0 || start >= len(p.buffer) {
-		p.eventCh <- fsmEvent{kind: eventError}
+		p.emitEvent(fsmEvent{kind: eventError, err: errBufferEmpty})
 		return
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	p.stateMu.Lock()
 	p.printCancel = cancel
+	p.stateMu.Unlock()
 
 	go func() {
 		defer cancel()
@@ -491,14 +530,13 @@ func (p *LXD02) printBuffer(start int) {
 				err := p.sendPacket(p.buffer[i])
 				if err != nil {
 					slog.Error("Failed to send packet", "packet", i, "error", err)
-					p.eventCh <- fsmEvent{kind: eventError}
+					p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send packet %d: %w", i, err)})
 					return
 				}
 			}
 		}
 
-		slog.Info("All packets sent, waiting for printer to complete (5a06)")
-		p.eventCh <- fsmEvent{kind: eventNotificationFinished}
+		p.emitEvent(fsmEvent{kind: eventPacketsSent})
 	}()
 }
 
@@ -524,12 +562,12 @@ func (p *LXD02) sendInitSequence() {
 		expectPrefix := cmd[:2]
 		resp, err := p.sendAndWait(cmd, expectPrefix, responseTimeout)
 		if err != nil {
-			p.eventCh <- fsmEvent{kind: eventError}
+			p.emitEvent(fsmEvent{kind: eventError, err: fmt.Errorf("send init command % x: %w", expectPrefix, err)})
 			return
 		}
 		slog.Debug("init ack", "prefix", fmt.Sprintf("% x", expectPrefix), "response", fmt.Sprintf("% x", resp))
 	}
-	p.eventCh <- fsmEvent{kind: eventInitComplete}
+	p.emitEvent(fsmEvent{kind: eventInitComplete})
 }
 
 func extractRetryPacketIndex(data []byte) int {

--- a/printerevent_string.go
+++ b/printerevent_string.go
@@ -13,17 +13,19 @@ func _() {
 	_ = x[eventNotificationRetransmit-2]
 	_ = x[eventNotificationFinished-3]
 	_ = x[eventInitComplete-4]
-	_ = x[eventCancel-5]
-	_ = x[eventError-6]
+	_ = x[eventPacketsSent-5]
+	_ = x[eventCancel-6]
+	_ = x[eventError-7]
 }
 
-const _printerEvent_name = "StartNotificationHoldNotificationRetransmitNotificationFinishedInitCompleteCancelError"
+const _printerEvent_name = "StartNotificationHoldNotificationRetransmitNotificationFinishedInitCompletePacketsSentCancelError"
 
-var _printerEvent_index = [...]uint8{0, 5, 21, 43, 63, 75, 81, 86}
+var _printerEvent_index = [...]uint8{0, 5, 21, 43, 63, 75, 86, 92, 97}
 
 func (i printerEvent) String() string {
-	if i < 0 || i >= printerEvent(len(_printerEvent_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_printerEvent_index)-1 {
 		return "printerEvent(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _printerEvent_name[_printerEvent_index[i]:_printerEvent_index[i+1]]
+	return _printerEvent_name[_printerEvent_index[idx]:_printerEvent_index[idx+1]]
 }

--- a/printerstate_string.go
+++ b/printerstate_string.go
@@ -10,17 +10,16 @@ func _() {
 	var x [1]struct{}
 	_ = x[stateIdle-0]
 	_ = x[stateInitializing-1]
-	_ = x[stateReady-2]
-	_ = x[statePrinting-3]
-	_ = x[statePaused-4]
-	_ = x[stateWaitingRetry-5]
-	_ = x[stateCompleted-6]
-	_ = x[stateFailed-7]
+	_ = x[statePrinting-2]
+	_ = x[statePaused-3]
+	_ = x[stateWaitingRetry-4]
+	_ = x[stateCompleted-5]
+	_ = x[stateFailed-6]
 }
 
-const _printerState_name = "IdleInitializingReadyPrintingPausedWaitingRetryCompletedFailed"
+const _printerState_name = "IdleInitializingPrintingPausedWaitingRetryCompletedFailed"
 
-var _printerState_index = [...]uint8{0, 4, 16, 21, 29, 35, 47, 56, 62}
+var _printerState_index = [...]uint8{0, 4, 16, 24, 30, 42, 51, 57}
 
 func (i printerState) String() string {
 	idx := int(i) - 0

--- a/printerstate_string.go
+++ b/printerstate_string.go
@@ -23,8 +23,9 @@ const _printerState_name = "IdleInitializingReadyPrintingPausedWaitingRetryCompl
 var _printerState_index = [...]uint8{0, 4, 16, 21, 29, 35, 47, 56, 62}
 
 func (i printerState) String() string {
-	if i < 0 || i >= printerState(len(_printerState_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_printerState_index)-1 {
 		return "printerState(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _printerState_name[_printerState_index[i]:_printerState_index[i+1]]
+	return _printerState_name[_printerState_index[idx]:_printerState_index[idx+1]]
 }


### PR DESCRIPTION
## Summary

Refactors the LX-D02 print-job state machine to use `github.com/looplab/fsm` and adds job-scoped routing for FSM side effects. Internal print events now dispatch directly to the owning print job instead of sharing the notification queue, while printer notifications remain best-effort and non-blocking.

## Why

The previous switch-based FSM mixed internal packet-stream completion with printer `5a06` completion and used shared channels that could deadlock or receive stale events. Follow-up review also found that required internal events could be dropped when the notification queue was full, and stale goroutines from a canceled print could affect the next print.

## Changes

- Add a per-print `printJob` owner for the FSM, notification queue, completion channel, cancellation, and packet-stream cancellation.
- Split internal `eventPacketsSent` from printer `eventNotificationFinished`.
- Dispatch required internal events directly through the owning job FSM so they cannot be dropped by a full notification queue.
- Ignore stale job events after cancellation or replacement by a later print.
- Return print failure/cancellation errors through single-shot completion handling.
- Keep public printing APIs unchanged.
- Update FSM tests to cover success, failures, cancellation, hold/retransmit, duplicate completion, full notification queues, stale init completion, stale packet stream events, and worker behavior with no active print.

## Validation

- `go test ./...`
- `go test -race ./...`